### PR TITLE
Change prefix path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,9 @@ cmake_minimum_required(VERSION 2.8.5)
 project (libSplash)
 
 #set helper pathes to find libraries and packages
-set(CMAKE_PREFIX_PATH "$ENV{MPI_ROOT}" "$ENV{HDF5_ROOT}")
+#- you need the multiarch dir x86_64-linux-gnu on 64bit Ubuntu's with
+#  self-compiled compilers
+set(CMAKE_PREFIX_PATH "/usr/lib/x86_64-linux-gnu/" "$ENV{MPI_ROOT}")
 
 #-------------------------------------------------------------------------------
 

--- a/examples/domain_read/CMakeLists.txt
+++ b/examples/domain_read/CMakeLists.txt
@@ -21,7 +21,7 @@
 cmake_minimum_required(VERSION 2.8.5)
 
 project (domain_read)
-set(CMAKE_PREFIX_PATH "/usr/lib/x86_64-linux-gnu/" "$ENV{HDF5_ROOT}")
+set(CMAKE_PREFIX_PATH "/usr/lib/x86_64-linux-gnu/" "$ENV{MPI_ROOT}")
 
 SET(CMAKE_CXX_FLAGS_DEBUG "-g")
 SET(CMAKE_BUILD_TYPE Debug)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,6 +1,8 @@
 # Projekt name
 cmake_minimum_required(VERSION 2.8.5)
 
+set(CMAKE_PREFIX_PATH "/usr/lib/x86_64-linux-gnu/" "$ENV{MPI_ROOT}")
+
 SET(CMAKE_BUILD_TYPE Debug)
 SET(CMAKE_CXX_FLAGS_DEBUG "-g")
 OPTION(WITH_MPI "use MPI-based tests" OFF)


### PR DESCRIPTION
- **FindHDF5.cmake:** honors the ENV variable HDF5_ROOT -> removed from Prefix
- **64bit Ubuntu:** if one uses self-compiled compilers and someone forgot to set
              the multiarch lib dir /usr/lib/x86_64-linux-gnu/ in the
              default compiler path we have to manually add this...
