### PR TITLE
README: link to gh-pages Doxygen Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Usage
 
 See [UserManual.pdf](doc/manual/UserManual.pdf?raw=true) for more information.
 You can find detailed information on all interfaces in our
-[Online Documentation](http://ComputationalRadiationPhysics.github.io/libSplash/html/).
+[Online Documentation](http://ComputationalRadiationPhysics.github.io/libSplash/).
 
 
 Active Team


### PR DESCRIPTION
I added our Doxygen documentation to _libSplash_'s [github pages](http://computationalradiationphysics.github.io/libSplash/).

Please note, that this branch is totally unrelated (an [orphan](https://help.github.com/articles/creating-project-pages-manually)) compared to our other branches.

To [update](https://github.com/ComputationalRadiationPhysics/libSplash/blob/gh-pages/update.sh) the documentation, run

``` bash
git checkout gh-pages
./update.sh <branchName>
```

If you specify no name, `master` will be the default branch to create the documentation for.
