### PR TITLE
Fix 28 Byte Dimensions Object

### DIFF
--- a/src/include/Dimensions.hpp
+++ b/src/include/Dimensions.hpp
@@ -1,24 +1,24 @@
 /**
- * Copyright 2013 Felix Schmitt
+ * Copyright 2013 Felix Schmitt, Axel Huebl
  *
- * This file is part of libSplash. 
- * 
- * libSplash is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
- * libSplash is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libSplash. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
- 
+ * This file is part of libSplash.
+ *
+ * libSplash is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * libSplash is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libSplash.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
 
 
 #ifndef _DIMENSIONS_H
@@ -63,7 +63,7 @@ namespace DCollector
         /**
          * Destructor
          */
-        virtual ~Dimensions()
+        ~Dimensions()
         {
 
         }


### PR DESCRIPTION
- the `virtual ~Destructor` blows up the object from 3x8=24 to _28 bytes_
- no-one inherits from Dimensions, so a _virtual destructor_ is **not necessary**
- &object (instead of .getPointer() ) calls will create corrupted data, for example all PIConGPU [Dimensions](https://github.com/ComputationalRadiationPhysics/picongpu/blob/master/src/picongpu/include/plugins/output/HDF5Writer.hpp#L526-L528) attributes ([here](https://github.com/ComputationalRadiationPhysics/picongpu/blob/master/src/picongpu/include/plugins/output/HDF5Writer.hpp#L574-L575), too) are corrupted, due to wrong usage of `&dimObj` instead `dimObj.getPointer()`
