### PR TITLE
Remove deprecated attributes

### DIFF
--- a/src/DCDataSet.cpp
+++ b/src/DCDataSet.cpp
@@ -589,17 +589,6 @@ namespace DCollector
             if (H5Dwrite(dataset, this->datatype, dsp_src, dataspace, dsetWriteProperties, data) < 0)
                 throw DCException(getExceptionString("write: Failed to write dataset"));
 
-            if (ndims > 1)
-            {
-                // write (client) size of this dataset
-                DCAttribute::writeAttribute(SDC_ATTR_SIZE, dimType.getDataType(),
-                        dataset, getLogicalSize().getPointer());
-
-                // mark this dataset as not combined
-                DCAttribute::writeAttribute(SDC_ATTR_MPI_SIZE, dimType.getDataType(),
-                        dataset, Dimensions(1, 1, 1).getPointer());
-            }
-
             H5Sclose(dsp_src);
         }
     }

--- a/src/ParallelDataCollector.cpp
+++ b/src/ParallelDataCollector.cpp
@@ -38,7 +38,7 @@ using namespace DCollector;
 void ParallelDataCollector::setFileAccessParams(hid_t& fileAccProperties)
 {
     fileAccProperties = H5Pcreate(H5P_FILE_ACCESS);
-    H5Pset_fapl_mpiposix(fileAccProperties, options.mpiComm, 0); //options.mpiInfo);
+    H5Pset_fapl_mpio(fileAccProperties, options.mpiComm, options.mpiInfo);
 
     int metaCacheElements = 0;
     size_t rawCacheElements = 0;
@@ -598,7 +598,7 @@ void ParallelDataCollector::append(int32_t id,
     DCDataSet::getFullDataPath(name, SDC_GROUP_DATA, id, group_path, dset_name);
 
     DCParallelGroup group;
-    group.openCreate(handles.get(id), group_path);
+    group.open(handles.get(id), group_path);
 
     // write data to the dataset
     DCParallelDataSet dataset(dset_name.c_str());


### PR DESCRIPTION
- do not write deprecated attributes for datasets
- use MPI I/O layer instead os POSIX
