### PR TITLE
getEnd Fix for dataContainer

### DIFF
--- a/src/include/domains/DataContainer.hpp
+++ b/src/include/domains/DataContainer.hpp
@@ -80,12 +80,12 @@ namespace DCollector
                 throw DCException("Data in entry in DataContainer must not be NULL.");
 
             const Dimensions &entryOffset = entry->getOffset();
-            const Dimensions entryEnd = entry->getEnd();
-            
+            const Dimensions entryBack = entry->getBack(); // last index INSIDE
+
             for (uint32_t i = 0; i < 3; ++i)
             {
                 offset[i] = std::min(entryOffset[i], offset[i]);
-                size[i] = std::max(entryEnd[i] - offset[i], size[i]);
+                size[i] = std::max(entryBack[i] + 1 - offset[i], size[i]);
             }
 
             subdomains.push_back(entry);
@@ -141,13 +141,13 @@ namespace DCollector
         
         /**
          * Returns the end of the partition represented by this container
-         * which is the combination of its offset and size.
+         * which is the combination of its offset and size - 1.
          * 
-         * @return End of total domain partition in this container.
+         * @return Last index of the total domain partition in this container.
          */
-        Dimensions getEnd() const
+        Dimensions getBack() const
         {
-            return offset + size;
+            return offset + size - Dimensions(1, 1, 1);
         }
 
         /**

--- a/src/include/domains/Domain.hpp
+++ b/src/include/domains/Domain.hpp
@@ -123,12 +123,12 @@ namespace DCollector
         }
 
         /**
-         * Returns the end of this domain which is the combination
-         * of its offset and size.
-         * 
-         * @return End of domain.
+         * Returns the last index of this domain which is the combination
+         * of its offset and size - 1
+         *
+         * @return Last index of domain.
          */
-        Dimensions getEnd() const
+        Dimensions getBack() const
         {
             return offset + size - Dimensions(1, 1, 1);
         }
@@ -154,7 +154,7 @@ namespace DCollector
             stream << "(offset: " << offset.toString() << ", size: " << size.toString() << ")";
             return stream.str();
         }
-        
+
         /**
          * Tests if two domains intersect.
          * 
@@ -166,8 +166,8 @@ namespace DCollector
         {
             Dimensions d1_offset = d1.getOffset();
             Dimensions d2_offset = d2.getOffset();
-            Dimensions d1_end = d1.getEnd();
-            Dimensions d2_end = d2.getEnd();
+            Dimensions d1_end = d1.getBack();
+            Dimensions d2_end = d2.getBack();
 
             return (d1_offset[0] <= d2_end[0] && d1_end[0] >= d2_offset[0] &&
                     d1_offset[1] <= d2_end[1] && d1_end[1] >= d2_offset[1] &&


### PR DESCRIPTION
- getEnd should be getBack if it means the LAST element
- harmonize Domain and DataContainer getEnd and rename
- fix readDomain for splash2txt
- fix comments to be more precise
