### PR TITLE
Use duplicate of MPI communicator, fix bugs

### DIFF
--- a/src/ParallelDataCollector.cpp
+++ b/src/ParallelDataCollector.cpp
@@ -132,11 +132,13 @@ namespace splash
     fileStatus(FST_CLOSED)
     {
         parseEnvVars();
+        
+        if (MPI_Comm_dup(comm, &(options.mpiComm)) != MPI_SUCCESS)
+            throw DCException(getExceptionString("ParallelDataCollector",
+                "failed to duplicate MPI communicator"));
 
-        MPI_Comm_rank(comm, &(options.mpiRank));
-
+        MPI_Comm_rank(options.mpiComm, &(options.mpiRank));
         options.enableCompression = false;
-        options.mpiComm = comm;
         options.mpiInfo = info;
         options.mpiSize = topology.getScalarSize();
         options.mpiTopology.set(topology);

--- a/tests/DomainsTest.cpp
+++ b/tests/DomainsTest.cpp
@@ -42,12 +42,10 @@ ctInt()
     dataCollector = new DomainCollector(3);
     srand(10);
 
-    int argc;
-    char** argv;
     int initialized;
     MPI_Initialized(&initialized);
     if (!initialized)
-        MPI_Init(&argc, &argv);
+        MPI_Init(NULL, NULL);
 
     MPI_Comm_size(MPI_COMM_WORLD, &totalMpiSize);
     MPI_Comm_rank(MPI_COMM_WORLD, &totalMpiRank);

--- a/tests/Parallel_AttributesTest.cpp
+++ b/tests/Parallel_AttributesTest.cpp
@@ -42,12 +42,10 @@ Parallel_AttributesTest::Parallel_AttributesTest()
 {
     srand(time(NULL));
 
-    int argc;
-    char** argv;
     int initialized;
     MPI_Initialized(&initialized);
     if( !initialized )
-        MPI_Init(&argc, &argv);
+        MPI_Init(NULL, NULL);
 
     int mpiSize;
     MPI_Comm_rank(MPI_COMM_WORLD, &mpiRank);

--- a/tests/Parallel_DomainsTest.cpp
+++ b/tests/Parallel_DomainsTest.cpp
@@ -50,12 +50,10 @@ parallelDomainCollector(NULL)
 {
     srand(10);
 
-    int argc;
-    char** argv;
     int initialized;
     MPI_Initialized(&initialized);
     if (!initialized)
-        MPI_Init(&argc, &argv);
+        MPI_Init(NULL, NULL);
 
     MPI_Comm_size(MPI_COMM_WORLD, &totalMpiSize);
     MPI_Comm_rank(MPI_COMM_WORLD, &myMpiRank);

--- a/tests/Parallel_ReferencesTest.cpp
+++ b/tests/Parallel_ReferencesTest.cpp
@@ -37,12 +37,10 @@ ctInt()
 {
     srand(time(NULL));
 
-    int argc;
-    char** argv;
     int initialized;
     MPI_Initialized(&initialized);
     if( !initialized )
-        MPI_Init(&argc, &argv);
+        MPI_Init(NULL, NULL);
 
     MPI_Comm_rank(MPI_COMM_WORLD, &mpiRank);
     MPI_Comm_size(MPI_COMM_WORLD, &mpiSize);

--- a/tests/Parallel_RemoveTest.cpp
+++ b/tests/Parallel_RemoveTest.cpp
@@ -37,12 +37,10 @@ using namespace splash;
 Parallel_RemoveTest::Parallel_RemoveTest() :
 ctInt()
 {
-    int argc;
-    char** argv;
     int initialized;
     MPI_Initialized(&initialized);
     if( !initialized )
-        MPI_Init(&argc, &argv);
+        MPI_Init(NULL, NULL);
 
     int mpiSize;
     MPI_Comm_rank(MPI_COMM_WORLD, &mpiRank);

--- a/tests/Parallel_SimpleDataTest.cpp
+++ b/tests/Parallel_SimpleDataTest.cpp
@@ -48,12 +48,10 @@ parallelDataCollector(NULL)
 {
     srand(10);
 
-    int argc;
-    char** argv;
     int initialized;
     MPI_Initialized(&initialized);
     if( !initialized )
-        MPI_Init(&argc, &argv);
+        MPI_Init(NULL, NULL);
 
     MPI_Comm_size(MPI_COMM_WORLD, &totalMpiSize);
     MPI_Comm_rank(MPI_COMM_WORLD, &myMpiRank);


### PR DESCRIPTION
- create duplicate of application MPI communicator as required by MPI
- fix segfaults in parallel tests
