### PR TITLE
Correct Find Static HDF5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,8 +56,12 @@ INCLUDE_DIRECTORIES(SYSTEM ${HDF5_INCLUDE_DIR})
 #   CMake prefers .so/shared libraries                 
 #   if we find a static HDF5 lib in the ${HDF5_LIBRARIES}
 #   it means there is only a static version installed
-SET(HDF5_IS_STATIC 0)
-STRING(FIND "${HDF5_LIBRARIES}" "hdf5.a" HDF5_IS_STATIC)
+STRING(FIND "${HDF5_LIBRARIES}" "hdf5\\.a" HDF5_IS_STATIC_POS)
+IF(${HDF5_IS_STATIC_POS} EQUAL -1)
+    SET(HDF_IS_STATIC OFF)
+ELSE(${HDF5_IS_STATIC_POS} EQUAL -1)
+    SET(HDF_IS_STATIC ON)
+ENDIF(${HDF5_IS_STATIC_POS} EQUAL -1)
 
 #-------------------------------------------------------------------------------
 


### PR DESCRIPTION
I got some issues on precise with cmake 2.8.5 stating there would be _only_ a static hdf5 lib installed.
- `string(FIND ...)` returns the position of the sub string or `-1`
  http://www.cmake.org/cmake/help/v2.8.8/cmake.html#command:string
- the substring "hdf5.a" uses a special character `.` which has to be escaped _twice_ by `\`'s
- `-1` is not one of the known boolean values (at least in cmake 2.8.5)
  http://www.cmake.org/Wiki/CMake/Language_Syntax#CMake_supports_boolean_variables.
