### PR TITLE
Topic splash2xdmf with relative nodepath

### DIFF
--- a/tools/splash2xdmf.py
+++ b/tools/splash2xdmf.py
@@ -296,6 +296,7 @@ def create_xdmf_poly_attribute(dset, h5filename):
    
     data_item_attr_text = doc.createTextNode("{}:{}".format(h5filename, dset.name))
     data_item_attr.appendChild(data_item_attr_text)    
+   
     attribute.appendChild(data_item_attr)
     
     poly.appendChild(attribute)


### PR DESCRIPTION
The textnodes in the output-xdmf-file now show the relative path of the node they belong to. We added a command line switch, which allows to print the full nodepath to the textnodes by adding "--fullpath" as parameter when you run splash2xdmf.py.
