### PR TITLE
Made the nodepaths relative by default

### DIFF
--- a/tools/splash2xdmf.py
+++ b/tools/splash2xdmf.py
@@ -463,12 +463,10 @@ def create_xdmf_for_splash_file(base_node_grid, base_node_poly, splashFilename, 
     
     if args.fullpath: 
     	splashFilenameXmf = splashFilename
-
     else:
         filename_list = splashFilename.split("/")
         splashFilenameXmf = filename_list[len(filename_list) - 1]
    
- 
     # find /data group
     dataGroup = h5file.get("data")
     if dataGroup == None:
@@ -479,6 +477,7 @@ def create_xdmf_for_splash_file(base_node_grid, base_node_poly, splashFilename, 
     time_step = get_timestep_for_group(dataGroup)
     
     parse_hdf5_recursive(dataGroup, splashFilenameXmf, 1)
+  
     # append all collected grids to current xml base node
     index = 0
     for grid in grids.values():
@@ -584,7 +583,7 @@ def get_args_parser():
     
     parser.add_argument("-t", "--time", help="Aggregate information over a time-series of libSplash data", action="store_true")
   
-    parser.add_argument("--fullpath", help="Disables relative node-paths", action="store_true")
+    parser.add_argument("--fullpath", help="Use absolute paths for HDF5 files", action="store_true")
     
     return parser
 


### PR DESCRIPTION
The textnodes in the output-xdmf-file now show the relative path of the node they belong to. We added a command line switch, which allows to print the full nodepath to the textnodes by adding "--fullpath" as parameter when you run splash2xdmf.py.

closes [106](https://github.com/ComputationalRadiationPhysics/libSplash/pull/106)
