### PR TITLE
Topic splash2xdmf with splited grids

### DIFF
--- a/tools/splash2xdmf.py
+++ b/tools/splash2xdmf.py
@@ -558,7 +558,7 @@ def create_xdmf_xml(splash_files_list, args):
         base_node_poly = domain
     else:
         base_node_grid = grid_domain
-	base_node_poly = poly_domain
+        base_node_poly = poly_domain
     
     if time_series:
         if args.splitgrid:		


### PR DESCRIPTION
I modified splash2xdmf and now you can get the output for the grid and the poly grids in two serparate output files. Just add "-- splitgrid" when you run splash2xdmf. 
