### PR TITLE
Topic splash2xdmf filename bugfix

### DIFF
--- a/tools/splash2xdmf.py
+++ b/tools/splash2xdmf.py
@@ -681,7 +681,6 @@ def main():
         tmp = splashFilename.rfind(".h5")
         splashFilename = splashFilename[:tmp]   
 
-
     create_xdmf_xml(splash_files, args)    
  
     output_filename = "{}.xmf".format(splashFilename)


### PR DESCRIPTION
Removed a filename bug which effected the script on single time steps. 

Refers to [#122](https://github.com/ComputationalRadiationPhysics/libSplash/issues/122) and [PIConGPU #330](https://github.com/ComputationalRadiationPhysics/picongpu/issues/330)
