### PR TITLE
Bump Version Number to 1.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 Change Log for libSplash
 ================================================================
 
+Release 1.2.2
+-------------
+**Date:** 2014-06-21
+
+That release was necessary since we forgot to bump the version
+number in <splash/version.hpp> with the last release.
+
+
 Release 1.2.1
 -------------
 **Date:** 2014-06-20

--- a/src/include/splash/version.hpp
+++ b/src/include/splash/version.hpp
@@ -2,18 +2,19 @@
  * Copyright 2013-2014 Felix Schmitt, Axel Huebl
  *
  * This file is part of libSplash. 
- * 
+ *
  * libSplash is free software: you can redistribute it and/or modify 
  * it under the terms of of either the GNU General Public License or 
  * the GNU Lesser General Public License as published by 
  * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
+ * (at your option) any later version.
+ *
  * libSplash is distributed in the hope that it will be useful, 
  * but WITHOUT ANY WARRANTY; without even the implied warranty of 
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
  * GNU General Public License and the GNU Lesser General Public License 
  * for more details. 
- * 
+ *
  * You should have received a copy of the GNU General Public License 
  * and the GNU Lesser General Public License along with libSplash. 
  * If not, see <http://www.gnu.org/licenses/>. 
@@ -25,7 +26,7 @@
 /** the splash version reflects the changes in API */
 #define SPLASH_VERSION_MAJOR 1
 #define SPLASH_VERSION_MINOR 2
-#define SPLASH_VERSION_PATCH 0
+#define SPLASH_VERSION_PATCH 2
 
 /** we can always handle files from the same major release
  *  changes in the minor number have to be backwards compatible


### PR DESCRIPTION
We forgot to bump the version number for  the `1.2.1` release.

The only clean way is to update it now and to draw a new release, `1.2.2`.
Sorry for that.
