### PR TITLE
Fix abs(size_t) Compile Error on Red Hat

### DIFF
--- a/src/include/splash/core/DCHelper.hpp
+++ b/src/include/splash/core/DCHelper.hpp
@@ -26,6 +26,7 @@
 
 #include <map>
 #include <cmath>
+#include <cstdlib>
 #include <sstream>
 #include <iostream>
 #include <hdf5.h>
@@ -147,7 +148,7 @@ namespace splash
             while (current_chunk_size < target_chunk_size)
             {
                 // test if increasing chunk size optimizes towards target chunk size
-                size_t chunk_diff = std::abs(target_chunk_size - (current_chunk_size * 2));
+                size_t chunk_diff = abs(target_chunk_size - (current_chunk_size * 2));
                 if (chunk_diff >= last_chunk_diff)
                     break;
 


### PR DESCRIPTION
### System
  Red Hat 4.4.7-3 + GCC 4.4.7
  (Scientific Linux 6 on LBL's [Lawrencium](https://sites.google.com/a/lbl.gov/high-performance-computing-services-group/lbnl-supercluster/lawrencium))

### Error message
  `DCHelper.hpp:151: error: call of overloaded 'abs(size_t)' is ambiguous`

`abs(size_t)` lives in `<cstdlib>` (not `<cmath>`) and is not in the `std::` namespace [1]

[1] http://compgroups.net/comp.lang.c++.moderated/std-abs-int-ambiguous/195658