### PR TITLE
[WIP] Pass error msgs from HDF5-functions

### DIFF
--- a/src/include/splash/core/DCDataSet.hpp
+++ b/src/include/splash/core/DCDataSet.hpp
@@ -254,6 +254,7 @@ namespace splash
         bool compression;
     private:
         std::string getExceptionString(std::string msg);
+        std::string getHDF5ExceptionString(std::string msg);
 
         ColTypeDim dimType;
     };

--- a/src/include/splash/core/DCDataSet.hpp
+++ b/src/include/splash/core/DCDataSet.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2014 Felix Schmitt
+ * Copyright 2013-2015 Felix Schmitt, Alexander Debus
  *
  * This file is part of libSplash. 
  * 
@@ -33,6 +33,8 @@
 #include "splash/Selection.hpp"
 #include "splash/CollectionType.hpp"
 #include "splash/basetypes/ColTypeDim.hpp"
+
+herr_t H5Ewalk_strings(unsigned n, const H5E_error2_t *err_desc, void *client_data);
 
 namespace splash
 {
@@ -258,7 +260,7 @@ namespace splash
     /**
      * \endcond
      */
-
+    
 }
 
 #endif	/* DCDATASET_HPP */


### PR DESCRIPTION
Referring to issue #160 I provide the first minimal code for solving the problem.

The code compiles, but is still in draft stage. The intention of this pull request is to discuss the best way forward before fleshing out the implementation, so nobody of us wastes too much time in later reviews.

The basic idea here is to extend `DCDataSet::getExceptionString(std::string msg)` to also include the current HDF5 error stack.
