### PR TITLE
Close #170 Simple Dataspaces for Attributes

### DIFF
--- a/src/DCAttribute.cpp
+++ b/src/DCAttribute.cpp
@@ -65,12 +65,6 @@ namespace splash
                                      uint32_t ndims, const Dimensions dims, const void* src)
     throw (DCException)
     {
-        if (name == NULL)
-            throw DCException(getExceptionString("attribute", "parameter name is NULL"));
-
-        if (ndims < 1u || ndims > 3u)
-            throw DCException(getExceptionString(name, "maximum dimension is invalid"));
-
         hid_t attr = -1;
         if (H5Aexists(parent, name))
             attr = H5Aopen(parent, name, H5P_DEFAULT);

--- a/src/ParallelDataCollector.cpp
+++ b/src/ParallelDataCollector.cpp
@@ -358,6 +358,9 @@ namespace splash
         if (fileStatus == FST_CLOSED || fileStatus == FST_READING)
             throw DCException(getExceptionString("writeGlobalAttribute", "this access is not permitted"));
 
+        if (ndims < 1u || ndims > DSP_DIM_MAX)
+            throw DCException(getExceptionString("writeGlobalAttribute", "maximum dimension `ndims` is invalid"));
+
         DCParallelGroup group_custom;
         group_custom.open(handles.get(id), SDC_GROUP_CUSTOM);
 
@@ -460,6 +463,9 @@ namespace splash
 
         if (fileStatus == FST_CLOSED || fileStatus == FST_READING)
             throw DCException(getExceptionString("writeAttribute", "this access is not permitted"));
+
+        if (ndims < 1u || ndims > DSP_DIM_MAX)
+            throw DCException(getExceptionString("writeAttribute", "maximum dimension `ndims` is invalid"));
 
         std::string group_path, obj_name;
         std::string dataNameInternal = "";

--- a/src/ParallelDataCollector.cpp
+++ b/src/ParallelDataCollector.cpp
@@ -340,6 +340,18 @@ namespace splash
             const void* data)
     throw (DCException)
     {
+        const Dimensions dims(1, 1, 1);
+        writeGlobalAttribute(id, type, name, 1u, dims, data);
+    }
+
+    void ParallelDataCollector::writeGlobalAttribute(int32_t id,
+            const CollectionType& type,
+            const char *name,
+            uint32_t ndims,
+            const Dimensions dims,
+            const void* data)
+    throw (DCException)
+    {
         if (name == NULL || data == NULL)
             throw DCException(getExceptionString("writeGlobalAttribute", "a parameter was null"));
 
@@ -351,7 +363,7 @@ namespace splash
 
         try
         {
-            DCAttribute::writeAttribute(name, type.getDataType(), group_custom.getHandle(), data);
+            DCAttribute::writeAttribute(name, type.getDataType(), group_custom.getHandle(), ndims, dims, data);
         } catch (DCException e)
         {
             log_msg(0, "Exception: %s", e.what());
@@ -422,6 +434,20 @@ namespace splash
             const void* data)
     throw (DCException)
     {
+        const Dimensions dims(1, 1, 1);
+        writeAttribute( id, type, dataName, attrName,
+                        1u, dims, data);
+    }
+
+    void ParallelDataCollector::writeAttribute(int32_t id,
+            const CollectionType& type,
+            const char *dataName,
+            const char *attrName,
+            uint32_t ndims,
+            const Dimensions dims,
+            const void* data)
+    throw (DCException)
+    {
         if (attrName == NULL || data == NULL)
             throw DCException(getExceptionString("writeAttribute", "a parameter was null"));
 
@@ -455,7 +481,7 @@ namespace splash
 
             try
             {
-                DCAttribute::writeAttribute(attrName, type.getDataType(), obj_id, data);
+                DCAttribute::writeAttribute(attrName, type.getDataType(), obj_id, ndims, dims, data);
             } catch (DCException)
             {
                 H5Oclose(obj_id);
@@ -466,7 +492,7 @@ namespace splash
         {
             // attach attribute to the iteration
             group.openCreate(handles.get(id), group_path);
-            DCAttribute::writeAttribute(attrName, type.getDataType(), group.getHandle(), data);
+            DCAttribute::writeAttribute(attrName, type.getDataType(), group.getHandle(), ndims, dims, data);
         }
     }
 

--- a/src/SerialDataCollector.cpp
+++ b/src/SerialDataCollector.cpp
@@ -247,6 +247,9 @@ namespace splash
         if (fileStatus == FST_CLOSED || fileStatus == FST_READING || fileStatus == FST_MERGING)
             throw DCException(getExceptionString("writeGlobalAttribute", "this access is not permitted"));
 
+        if (ndims < 1u || ndims > DSP_DIM_MAX)
+            throw DCException(getExceptionString("writeGlobalAttribute", "maximum dimension `ndims` is invalid"));
+
         DCGroup group_custom;
         group_custom.open(handles.get(0), SDC_GROUP_CUSTOM);
 
@@ -357,6 +360,9 @@ namespace splash
 
         if (fileStatus == FST_CLOSED || fileStatus == FST_READING || fileStatus == FST_MERGING)
             throw DCException(getExceptionString("writeAttribute", "this access is not permitted"));
+
+        if (ndims < 1u || ndims > DSP_DIM_MAX)
+            throw DCException(getExceptionString("writeAttribute", "maximum dimension `ndims` is invalid"));
 
         std::string group_path, obj_name;
         std::string dataNameInternal = "";

--- a/src/SerialDataCollector.cpp
+++ b/src/SerialDataCollector.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2014 Felix Schmitt
+ * Copyright 2013-2015 Felix Schmitt, Axel Huebl
  *
  * This file is part of libSplash. 
  * 
@@ -230,6 +230,17 @@ namespace splash
             const void* data)
     throw (DCException)
     {
+        const Dimensions dims(1, 1, 1);
+        writeGlobalAttribute(type, name, 1u, dims, data);
+    }
+
+    void SerialDataCollector::writeGlobalAttribute(const CollectionType& type,
+            const char* name,
+            uint32_t ndims,
+            const Dimensions dims,
+            const void* data)
+    throw (DCException)
+    {
         if (name == NULL || data == NULL)
             throw DCException(getExceptionString("writeGlobalAttribute", "a parameter was null"));
 
@@ -241,7 +252,7 @@ namespace splash
 
         try
         {
-            DCAttribute::writeAttribute(name, type.getDataType(), group_custom.getHandle(), data);
+            DCAttribute::writeAttribute(name, type.getDataType(), group_custom.getHandle(), ndims, dims, data);
         } catch (DCException e)
         {
             std::cerr << e.what() << std::endl;
@@ -320,6 +331,20 @@ namespace splash
             const void* data)
     throw (DCException)
     {
+        const Dimensions dims(1, 1, 1);
+        SerialDataCollector::writeAttribute( id, type, dataName, attrName,
+                                             1u, dims, data);
+    }
+
+    void SerialDataCollector::writeAttribute(int32_t id,
+            const CollectionType& type,
+            const char *dataName,
+            const char *attrName,
+            uint32_t ndims,
+            const Dimensions dims,
+            const void* data)
+    throw (DCException)
+    {
         if (attrName == NULL || data == NULL)
             throw DCException(getExceptionString("writeAttribute", "a parameter was null"));
 
@@ -354,7 +379,7 @@ namespace splash
 
             try
             {
-                DCAttribute::writeAttribute(attrName, type.getDataType(), obj_id, data);
+                DCAttribute::writeAttribute(attrName, type.getDataType(), obj_id, ndims, dims, data);
             } catch (DCException)
             {
                 H5Oclose(obj_id);
@@ -365,7 +390,7 @@ namespace splash
         {
             // attach attribute to the iteration group
             group.openCreate(handles.get(0), group_path);
-            DCAttribute::writeAttribute(attrName, type.getDataType(), group.getHandle(), data);
+            DCAttribute::writeAttribute(attrName, type.getDataType(), group.getHandle(), ndims, dims, data);
         }
     }
 

--- a/src/include/splash/DataCollector.hpp
+++ b/src/include/splash/DataCollector.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2014 Felix Schmitt
+ * Copyright 2013-2015 Felix Schmitt, Axel Huebl
  *
  * This file is part of libSplash. 
  * 
@@ -319,6 +319,21 @@ namespace splash
                 const char *name,
                 const void* buf) = 0;
 
+       /**
+         * Writes global attribute to HDF5 file (default group).
+         *
+         * @param type Type information for data.
+         * @param name Name of the attribute.
+         * @param ndims Number of dimensions (1-3)
+         * @param dims Number of elements
+         * @param buf Buffer to be written as attribute.
+         */
+        virtual void writeGlobalAttribute(const CollectionType& type,
+                const char *name,
+                uint32_t ndims,
+                const Dimensions dims,
+                const void* buf) = 0;
+
         /**
          * Reads an attribute from a single dataset.
          * 
@@ -352,7 +367,27 @@ namespace splash
                 const char *dataName,
                 const char *attrName,
                 const void *buf) = 0;
-        
+
+        /**
+         * Writes an attribute to a single dataset.
+         *
+         * @param id ID for iteration.
+         * @param type Type information for data.
+         * @param dataName Name of the dataset in group \p id to write attribute to.
+         * If dataName is NULL, the attribute is written for the iteration group.
+         * @param attrName Name of the attribute.
+         * @param ndims Number of dimensions (1-3)
+         * @param dims Number of elements
+         * @param buf Buffer to be written as attribute.
+         */
+        virtual void writeAttribute(int32_t id,
+                const CollectionType& type,
+                const char *dataName,
+                const char *attrName,
+                uint32_t ndims,
+                const Dimensions dims,
+                const void *buf) = 0;
+
         /**
          * Reads data from HDF5 file.
          * If data is to be read (instead of only its size in the file),

--- a/src/include/splash/IParallelDataCollector.hpp
+++ b/src/include/splash/IParallelDataCollector.hpp
@@ -125,7 +125,14 @@ namespace splash
                 const CollectionType& type,
                 const char *name,
                 const void* buf) = 0;
-        
+
+        virtual void writeGlobalAttribute(int32_t id,
+                const CollectionType& type,
+                const char *name,
+                uint32_t ndims,
+                const Dimensions dims,
+                const void* buf) = 0;
+
         virtual void readGlobalAttribute(const char *name,
                 void* buf,
                 Dimensions *mpiPosition = NULL) = 0;
@@ -133,7 +140,13 @@ namespace splash
         virtual void writeGlobalAttribute(const CollectionType& type,
                 const char *name,
                 const void* buf) = 0;
-        
+
+        virtual void writeGlobalAttribute(const CollectionType& type,
+                const char *name,
+                uint32_t ndims,
+                const Dimensions dims,
+                const void* buf) = 0;
+
         /**
          * Appends (1-3) dimensional data to a dataset created with
          * \ref IParallelDataCollector::reserve.

--- a/src/include/splash/ParallelDataCollector.hpp
+++ b/src/include/splash/ParallelDataCollector.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2014 Felix Schmitt
+ * Copyright 2013-2015 Felix Schmitt, Axel Huebl
  *
  * This file is part of libSplash. 
  * 
@@ -272,6 +272,13 @@ namespace splash
                 const char *name,
                 const void* buf) throw (DCException);
 
+        void writeGlobalAttribute(int32_t id,
+                const CollectionType& type,
+                const char *name,
+                uint32_t ndims,
+                const Dimensions dims,
+                const void* buf) throw (DCException);
+
         void readAttribute(int32_t id,
                 const char *dataName,
                 const char *attrName,
@@ -282,6 +289,14 @@ namespace splash
                 const CollectionType& type,
                 const char *dataName,
                 const char *attrName,
+                const void *buf) throw (DCException);
+
+        void writeAttribute(int32_t id,
+                const CollectionType& type,
+                const char *dataName,
+                const char *attrName,
+                uint32_t ndims,
+                const Dimensions dims,
                 const void *buf) throw (DCException);
 
         void read(int32_t id,
@@ -351,6 +366,15 @@ namespace splash
 
         void writeGlobalAttribute(const CollectionType& /*type*/,
                 const char* /*name*/,
+                const void* /*data*/)
+        {
+
+        }
+
+        void writeGlobalAttribute(const CollectionType& /*type*/,
+                const char* /*name*/,
+                uint32_t /*ndims*/,
+                const Dimensions /*dims*/,
                 const void* /*data*/)
         {
 

--- a/src/include/splash/SerialDataCollector.hpp
+++ b/src/include/splash/SerialDataCollector.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2014 Felix Schmitt
+ * Copyright 2013-2015 Felix Schmitt, Axel Huebl
  *
  * This file is part of libSplash. 
  * 
@@ -284,6 +284,12 @@ namespace splash
                 const char *name,
                 const void* data) throw (DCException);
 
+        void writeGlobalAttribute(const CollectionType& type,
+                const char *name,
+                uint32_t ndims,
+                const Dimensions dims,
+                const void* data) throw (DCException);
+
         void readAttribute(int32_t id,
                 const char *dataName,
                 const char *attrName,
@@ -294,6 +300,14 @@ namespace splash
                 const CollectionType& type,
                 const char *dataName,
                 const char *attrName,
+                const void *data) throw (DCException);
+
+        void writeAttribute(int32_t id,
+                const CollectionType& type,
+                const char *dataName,
+                const char *attrName,
+                uint32_t ndims,
+                const Dimensions dims,
                 const void *data) throw (DCException);
 
         void read(int32_t id,

--- a/src/include/splash/core/DCAttribute.hpp
+++ b/src/include/splash/core/DCAttribute.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Felix Schmitt
+ * Copyright 2013, 2015 Felix Schmitt, Axel Huebl
  *
  * This file is part of libSplash. 
  * 
@@ -27,6 +27,7 @@
 #include <hdf5.h>
 
 #include "splash/DCException.hpp"
+#include "splash/Dimensions.hpp"
 
 namespace splash
 {
@@ -50,7 +51,7 @@ namespace splash
 
         /**
          * Basic static method for writing an attribute.
-         * 
+         *
          * @param name name of the attribute
          * @param type datatype information of the attribute
          * @param parent parent object to add attribute to
@@ -60,6 +61,25 @@ namespace splash
                 const hid_t type,
                 hid_t parent,
                 const void *src) throw (DCException);
+
+
+        /**
+         * Basic static method for writing an attribute.
+         *
+         * @param name name of the attribute
+         * @param type datatype information of the attribute
+         * @param parent parent object to add attribute to
+         * @param ndims Number of dimensions (1-3)
+         * @param dims Number of elements
+         * @param src buffer with value
+         */
+        static void writeAttribute(const char *name,
+                const hid_t type,
+                hid_t parent,
+                uint32_t ndims,
+                const Dimensions dims,
+                const void *src) throw (DCException);
+
     private:
         DCAttribute();
         

--- a/src/include/splash/version.hpp
+++ b/src/include/splash/version.hpp
@@ -32,6 +32,6 @@
  *  changes in the minor number have to be backwards compatible
  */
 #define SPLASH_FILE_FORMAT_MAJOR 3
-#define SPLASH_FILE_FORMAT_MINOR 1
+#define SPLASH_FILE_FORMAT_MINOR 2
 
 #endif	/* VERSION_HPP */

--- a/tests/AttributesTest.cpp
+++ b/tests/AttributesTest.cpp
@@ -92,7 +92,7 @@ void AttributesTest::testDataAttributes()
             DCException);
     CPPUNIT_ASSERT_THROW(dataCollector->writeAttribute(10, ctInt, "", "", &sum2),
             DCException);
-    
+
     dataCollector->write(0, ctInt2, 1, Selection(Dimensions(BUF_SIZE, 1, 1)),
             "datasets/my_dataset", dummy_data);
     
@@ -105,6 +105,9 @@ void AttributesTest::testDataAttributes()
     dataCollector->writeAttribute(0, ctInt, "datasets", "sum_at_group", &sum);
     dataCollector->writeAttribute(0, ctChar, "datasets", "my_char", &c);
     dataCollector->writeAttribute(0, ctDouble, "datasets", "unitDimension", 1u, Dimensions(7,0,0), d);
+
+    CPPUNIT_ASSERT_THROW(dataCollector->writeAttribute(0, ctDouble, "datasets",
+            "invalnDims", 4u, Dimensions(7,0,0), d), DCException);
 
     delete[] dummy_data;
     dummy_data = NULL;

--- a/tests/AttributesTest.cpp
+++ b/tests/AttributesTest.cpp
@@ -101,8 +101,10 @@ void AttributesTest::testDataAttributes()
     dataCollector->writeAttribute(0, ctInt, "datasets/my_dataset", "neg_sum", &neg_sum);
 
     char c = 'Y';
+    double d[7] = {-3.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0};
     dataCollector->writeAttribute(0, ctInt, "datasets", "sum_at_group", &sum);
     dataCollector->writeAttribute(0, ctChar, "datasets", "my_char", &c);
+    dataCollector->writeAttribute(0, ctDouble, "datasets", "unitDimension", 1u, Dimensions(7,0,0), d);
 
     delete[] dummy_data;
     dummy_data = NULL;
@@ -153,11 +155,15 @@ void AttributesTest::testDataAttributes()
     CPPUNIT_ASSERT(sum == old_sum);
     CPPUNIT_ASSERT(neg_sum == -old_sum);
 
+    double dr[7] = {0., 0., 0., 0., 0., 0., 0.};
     dataCollector->readAttribute(0, "datasets", "sum_at_group", &sum);
     dataCollector->readAttribute(0, "datasets", "my_char", &c);
+    dataCollector->readAttribute(0, "datasets", "unitDimension", dr);
 
     CPPUNIT_ASSERT(sum == old_sum);
     CPPUNIT_ASSERT(c == 'Y');
+    for (int i = 0; i < 7; i++)
+        CPPUNIT_ASSERT(dr[i] == d[i]);
 
     dataCollector->close();
 }
@@ -172,22 +178,26 @@ void AttributesTest::testArrayTypes()
     Dimensions dim_write(104, 0, 2);
     
     dataCollector->open(TEST_FILE2, attr);
-    dataCollector->writeGlobalAttribute(ctInt3Array, "testposition", array_data_write);
+    dataCollector->writeGlobalAttribute(ctInt3Array, "testpositionArray", array_data_write);
+    dataCollector->writeGlobalAttribute(ctInt, "testposition", 1u, Dimensions(3, 1, 1), array_data_write);
     dataCollector->writeGlobalAttribute(ctDimArray, "testdim", dim_write.getPointer());
     dataCollector->close();
     
     int array_data_read[3] = {0, 0, 0};
+    int data_read[3] = {0, 0, 0};
     Dimensions dim_read;
     
     attr.fileAccType = DataCollector::FAT_READ;
     dataCollector->open(TEST_FILE2, attr);
-    dataCollector->readGlobalAttribute("testposition", array_data_read);
+    dataCollector->readGlobalAttribute("testpositionArray", array_data_read);
+    dataCollector->readGlobalAttribute("testposition", data_read);
     dataCollector->readGlobalAttribute("testdim", dim_read.getPointer());
     dataCollector->close();
     
     for (int i = 0; i < 3; i++)
     {
         CPPUNIT_ASSERT(array_data_read[i] == array_data_write[i]);
+        CPPUNIT_ASSERT(data_read[i] == array_data_write[i]);
         CPPUNIT_ASSERT(dim_write[i] == dim_read[i]);
     }
 }

--- a/tests/Parallel_AttributesTest.cpp
+++ b/tests/Parallel_AttributesTest.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2014 Felix Schmitt
+ * Copyright 2013-2015 Felix Schmitt, Axel Huebl
  *
  * This file is part of libSplash.
  *
@@ -161,22 +161,26 @@ void Parallel_AttributesTest::testArrayTypes()
             MPI_COMM_WORLD, MPI_INFO_NULL, Dimensions(MPI_SIZE_X, MPI_SIZE_Y, 1), 1);
 
     dataCollector->open(TEST_FILE2, attr);
-    dataCollector->writeGlobalAttribute(10, ctInt3Array, "testposition", array_data_write);
+    dataCollector->writeGlobalAttribute(10, ctInt3Array, "testpositionArray", array_data_write);
+    dataCollector->writeGlobalAttribute(10, ctInt, "testposition", 1u, Dimensions(3, 1, 1), array_data_write);
     dataCollector->writeGlobalAttribute(20, ctDimArray, "testdim", dim_write.getPointer());
     dataCollector->close();
 
     int array_data_read[3] = {0, 0, 0};
+    int data_read[3] = {0, 0, 0};
     Dimensions dim_read;
 
     attr.fileAccType = DataCollector::FAT_READ;
     dataCollector->open(TEST_FILE2, attr);
-    dataCollector->readGlobalAttribute(10, "testposition", array_data_read);
+    dataCollector->readGlobalAttribute(10, "testpositionArray", array_data_read);
+    dataCollector->readGlobalAttribute(10, "testposition", data_read);
     dataCollector->readGlobalAttribute(20, "testdim", dim_read.getPointer());
     dataCollector->close();
 
     for (int i = 0; i < 3; i++)
     {
         CPPUNIT_ASSERT(array_data_read[i] == array_data_write[i]);
+        CPPUNIT_ASSERT(data_read[i] == array_data_write[i]);
         CPPUNIT_ASSERT(dim_write[i] == dim_read[i]);
     }
 

--- a/tests/include/AttributesTest.h
+++ b/tests/include/AttributesTest.h
@@ -46,6 +46,7 @@ private:
     void testArrayTypes();
 
     ColTypeChar ctChar;
+    ColTypeDouble ctDouble;
     ColTypeInt ctInt;
     ColTypeInt2 ctInt2;
     ColTypeInt3Array ctInt3Array;

--- a/tests/readBoolChar.py
+++ b/tests/readBoolChar.py
@@ -24,7 +24,7 @@
 import h5py
 import numpy as np
 
-# bool compatible data sets
+# bool compatible data sets ###################################################
 f = h5py.File("h5/testWriteRead_0_0_0.h5", "r")
 data = f["data/10/deep/folders/data_bool"]
 
@@ -38,8 +38,28 @@ for i in np.arange(len):
 
 f.close()
 
-# single char compatible attributes
+# compatible attributes #######################################################
+f = h5py.File("h5/attributes_array_0_0_0.h5", "r")
+
+# array attributes
+dg = f["custom"].attrs["testposition"]
+print(dg, type(dg), dg.dtype)
+
+ref_dg = np.array([17, 12, -99], dtype="int")
+if not np.array_equal(dg, ref_dg):
+    exit(1)
+
+f.close()
 f = h5py.File("h5/attributes_0_0_0.h5", "r")
+
+d = f["data/0/datasets"].attrs["unitDimension"]
+print(d, type(d), d.dtype)
+
+ref_d = np.array([-3., 0., 1., 1., 0., 0., 0.], dtype="float64")
+if not np.array_equal(d, ref_d):
+    exit(1)
+
+# single char compatible attributes
 c = f["data/0/datasets"].attrs["my_char"]
 
 # h5py, as of 2.5.0, does not know char and


### PR DESCRIPTION
Close #170 by implementing additional interfaces to write attributes (global and per iteration) that can be used with simple HDF5 dataspaces.

"Simple Dataspaces" were only used with data sets, e.g., arrays or matrices but are the first choice for actual multi-dimensional array attributes, too (and compatible with `h5py`). Currently, we only supported to use specific types (see #170) that were either `compound` (different types) or `array` (N-times the same) types.

### To Do

- [ ] update `gh-pages` after this pull was merged
- [x] update file format version by a minor to `3.2`