### PR TITLE
Travis: Run tests in "script"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,8 +32,7 @@ script:
 # compile and run tests/
   - cmake -DWITH_MPI=$SPLASHMPI $SRC/tests
   - make
-
-after_script:
+# run tests
   - $SRC/tests/run_tests $BUILD
   - $SRC/tests/run_parallel_tests $BUILD
 


### PR DESCRIPTION
Non-zero return types of scripts in the `after_script` section do NOT mark the build as failed:
  http://docs.travis-ci.com/user/build-lifecycle/