### PR TITLE
Use the define DSP_DIM_MAX instead of 3

### DIFF
--- a/src/DomainCollector.cpp
+++ b/src/DomainCollector.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2014 Felix Schmitt, Axel Huebl
+ * Copyright 2013-2015 Felix Schmitt, Axel Huebl
  *
  * This file is part of libSplash. 
  * 
@@ -8,6 +8,7 @@
  * the GNU Lesser General Public License as published by 
  * the Free Software Foundation, either version 3 of the License, or 
  * (at your option) any later version. 
+ *
  * libSplash is distributed in the hope that it will be useful, 
  * but WITHOUT ANY WARRANTY; without even the implied warranty of 
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
@@ -504,7 +505,7 @@ namespace splash
                         minDom.getOffset().toString().c_str(),
                         maxDom.getOffset().toString().c_str());
 
-                for (size_t i = 0; i < 3; ++i)
+                for (size_t i = 0; i < DSP_DIM_MAX; ++i)
                 {
                     // zero still between min and max?
                     if (minDom.getOffset()[i] > maxDom.getOffset()[i])
@@ -531,7 +532,7 @@ namespace splash
             Domain lastDom;
             readDomainInfoForRank(mpi_size - Dimensions(1, 1, 1), id, name,
                     Domain(Dimensions(0, 0, 0), Dimensions(0, 0, 0)), lastDom);
-            for (size_t i = 0; i < 3; ++i)
+            for (size_t i = 0; i < DSP_DIM_MAX; ++i)
             {
                 if (request_offset[i] <= lastDom.getBack()[i])
                 {
@@ -564,7 +565,7 @@ namespace splash
             last_mpi_pos = current_mpi_pos;
 
             // set current_mpi_pos to be the 'center' between min_dims and max_dims
-            for (size_t i = 0; i < 3; ++i)
+            for (size_t i = 0; i < DSP_DIM_MAX; ++i)
             {
                 current_mpi_pos[i] = min_dims[i] +
                         ceil(((double) max_dims[i] - (double) min_dims[i]) / 2.0);
@@ -577,7 +578,7 @@ namespace splash
                 break;
             }
 
-            for (size_t i = 0; i < 3; ++i)
+            for (size_t i = 0; i < DSP_DIM_MAX; ++i)
             {
                 if (request_offset[i] >= file_domain.getOffset()[i])
                     min_dims[i] = current_mpi_pos[i];
@@ -599,7 +600,7 @@ namespace splash
         // the file domain is added to the DataContainer.
 
         // set new min_dims to top-left corner
-        for (size_t i = 0; i < 3; ++i)
+        for (size_t i = 0; i < DSP_DIM_MAX; ++i)
             max_dims[i] = (current_mpi_pos[i] + mpi_size[i] - 1) % mpi_size[i];
         min_dims = current_mpi_pos;
 
@@ -794,10 +795,10 @@ namespace splash
             readAttribute(id, dataName, DOMCOL_ATTR_GLOBAL_SIZE, data, mpiPosition);
         } catch (DCException)
         {
-            hsize_t local_size[3];
+            hsize_t local_size[DSP_DIM_MAX];
             readAttribute(id, dataName, DOMCOL_ATTR_SIZE, local_size, mpiPosition);
 
-            for (int i = 0; i < 3; ++i)
+            for (int i = 0; i < DSP_DIM_MAX; ++i)
                 data[i] = mpiTopology[i] * local_size[i];
         }
     }
@@ -813,7 +814,7 @@ namespace splash
             readAttribute(id, dataName, DOMCOL_ATTR_GLOBAL_OFFSET, data, mpiPosition);
         } catch (DCException)
         {
-            for (int i = 0; i < 3; ++i)
+            for (int i = 0; i < DSP_DIM_MAX; ++i)
                 data[i] = 0;
         }
     }

--- a/src/ParallelDataCollector.cpp
+++ b/src/ParallelDataCollector.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2014 Felix Schmitt
+ * Copyright 2013-2015 Felix Schmitt, Axel Huebl
  *
  * This file is part of libSplash. 
  * 
@@ -8,6 +8,7 @@
  * the GNU Lesser General Public License as published by 
  * the Free Software Foundation, either version 3 of the License, or 
  * (at your option) any later version. 
+ *
  * libSplash is distributed in the hope that it will be useful, 
  * but WITHOUT ANY WARRANTY; without even the implied warranty of 
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
@@ -544,7 +545,7 @@ namespace splash
         if (fileStatus == FST_CLOSED || fileStatus == FST_READING)
             throw DCException(getExceptionString("write", "this access is not permitted"));
 
-        if (ndims < 1 || ndims > 3)
+        if (ndims < 1 || ndims > DSP_DIM_MAX)
             throw DCException(getExceptionString("write", "maximum dimension is invalid"));
 
         // create group for this id/iteration
@@ -571,7 +572,7 @@ namespace splash
         if (fileStatus == FST_CLOSED || fileStatus == FST_READING)
             throw DCException(getExceptionString("write", "this access is not permitted"));
 
-        if (ndims < 1 || ndims > 3)
+        if (ndims < 1 || ndims > DSP_DIM_MAX)
             throw DCException(getExceptionString("write", "maximum dimension is invalid"));
 
         reserveInternal(id, globalSize, ndims, type, name);
@@ -591,7 +592,7 @@ namespace splash
         if (fileStatus == FST_CLOSED || fileStatus == FST_READING)
             throw DCException(getExceptionString("write", "this access is not permitted"));
 
-        if (ndims < 1 || ndims > 3)
+        if (ndims < 1 || ndims > DSP_DIM_MAX)
             throw DCException(getExceptionString("write", "maximum dimension is invalid"));
 
         Dimensions global_size, global_offset;
@@ -619,7 +620,7 @@ namespace splash
         if (fileStatus == FST_CLOSED || fileStatus == FST_READING)
             throw DCException(getExceptionString("append", "this access is not permitted"));
 
-        if (ndims < 1 || ndims > 3)
+        if (ndims < 1 || ndims > DSP_DIM_MAX)
             throw DCException(getExceptionString("append", "maximum dimension is invalid"));
 
         // create group for this id/iteration
@@ -928,14 +929,14 @@ namespace splash
             Dimensions &globalSize, Dimensions &globalOffset)
     throw (DCException)
     {
-        uint64_t write_sizes[options.mpiSize * 3];
-        uint64_t local_write_size[3] = {localSize[0], localSize[1], localSize[2]};
+        uint64_t write_sizes[options.mpiSize * DSP_DIM_MAX];
+        uint64_t local_write_size[DSP_DIM_MAX] = {localSize[0], localSize[1], localSize[2]};
 
         globalSize.set(1, 1, 1);
         globalOffset.set(0, 0, 0);
 
-        if (MPI_Allgather(local_write_size, 3, MPI_UNSIGNED_LONG_LONG,
-                write_sizes, 3, MPI_UNSIGNED_LONG_LONG, options.mpiComm) != MPI_SUCCESS)
+        if (MPI_Allgather(local_write_size, DSP_DIM_MAX, MPI_UNSIGNED_LONG_LONG,
+                write_sizes, DSP_DIM_MAX, MPI_UNSIGNED_LONG_LONG, options.mpiComm) != MPI_SUCCESS)
             throw DCException(getExceptionString("gatherMPIWrites",
                 "MPI_Allgather failed", NULL));
 
@@ -971,9 +972,9 @@ namespace splash
                         index = dim * tmp_mpi_topology[0] * tmp_mpi_topology[1];
                 }
 
-                globalSize[i] += write_sizes[index * 3 + i];
+                globalSize[i] += write_sizes[index * DSP_DIM_MAX + i];
                 if (dim < tmp_mpi_pos[i])
-                    globalOffset[i] += write_sizes[index * 3 + i];
+                    globalOffset[i] += write_sizes[index * DSP_DIM_MAX + i];
             }
         }
     }

--- a/src/SerialDataCollector.cpp
+++ b/src/SerialDataCollector.cpp
@@ -404,7 +404,7 @@ namespace splash
         if (fileStatus == FST_CLOSED || fileStatus == FST_READING || fileStatus == FST_MERGING)
             throw DCException(getExceptionString("write", "this access is not permitted"));
 
-        if (ndims < 1 || ndims > 3)
+        if (ndims < 1 || ndims > DSP_DIM_MAX)
             throw DCException(getExceptionString("write", "maximum dimension is invalid"));
 
         if (id > this->maxID)

--- a/src/include/splash/Dimensions.hpp
+++ b/src/include/splash/Dimensions.hpp
@@ -28,6 +28,8 @@
 #include <sstream>
 #include <hdf5.h>
 
+#define DSP_DIM_MAX 3
+
 namespace splash
 {
 

--- a/src/include/splash/Dimensions.hpp
+++ b/src/include/splash/Dimensions.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Felix Schmitt, Axel Huebl
+ * Copyright 2013, 2015 Felix Schmitt, Axel Huebl
  *
  * This file is part of libSplash.
  *
@@ -8,6 +8,7 @@
  * the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
+ *
  * libSplash is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -37,7 +38,7 @@ namespace splash
     class Dimensions
     {
     private:
-        hsize_t s[3];
+        hsize_t s[DSP_DIM_MAX];
     public:
 
         /**
@@ -208,7 +209,7 @@ namespace splash
          */
         inline static size_t getSize()
         {
-            return 3 * sizeof (hsize_t);
+            return DSP_DIM_MAX * sizeof (hsize_t);
         }
 
         /**
@@ -250,7 +251,7 @@ namespace splash
          */
         inline uint32_t getDims(void) const
         {
-            uint32_t dims = 3;
+            uint32_t dims = DSP_DIM_MAX;
             if (s[2] == 1)
             {
                 dims = 2;
@@ -268,7 +269,7 @@ namespace splash
         void swapDims(uint32_t dims)
         {
             hsize_t tmp1 = s[0];
-            hsize_t tmp2[3] = {s[2], s[1], s[0]};
+            hsize_t tmp2[DSP_DIM_MAX] = {s[2], s[1], s[0]};
 
             switch (dims)
             {

--- a/src/include/splash/core/DCHelper.hpp
+++ b/src/include/splash/core/DCHelper.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Felix Schmitt
+ * Copyright 2013, 2015 Felix Schmitt, Axel Huebl
  *
  * This file is part of libSplash. 
  * 
@@ -8,6 +8,7 @@
  * the GNU Lesser General Public License as published by 
  * the Free Software Foundation, either version 3 of the License, or 
  * (at your option) any later version. 
+ *
  * libSplash is distributed in the hope that it will be useful, 
  * but WITHOUT ANY WARRANTY; without even the implied warranty of 
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
@@ -65,7 +66,7 @@ namespace splash
                 return;
 
             hsize_t tmp1;
-            hsize_t tmp3[3];
+            hsize_t tmp3[DSP_DIM_MAX];
 
             switch (rank)
             {

--- a/src/include/splash/domains/DataContainer.hpp
+++ b/src/include/splash/domains/DataContainer.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Felix Schmitt
+ * Copyright 2013, 2015 Felix Schmitt, Axel Huebl
  *
  * This file is part of libSplash. 
  * 
@@ -7,7 +7,8 @@
  * it under the terms of of either the GNU General Public License or 
  * the GNU Lesser General Public License as published by 
  * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
+ * (at your option) any later version.
+ *
  * libSplash is distributed in the hope that it will be useful, 
  * but WITHOUT ANY WARRANTY; without even the implied warranty of 
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
@@ -82,7 +83,7 @@ namespace splash
             const Dimensions &entryOffset = entry->getOffset();
             const Dimensions entryBack = entry->getBack(); // last index INSIDE
 
-            for (uint32_t i = 0; i < 3; ++i)
+            for (uint32_t i = 0; i < DSP_DIM_MAX; ++i)
             {
                 offset[i] = std::min(entryOffset[i], offset[i]);
                 size[i] = std::max(entryBack[i] + 1 - offset[i], size[i]);

--- a/src/include/splash/sdc_defines.hpp
+++ b/src/include/splash/sdc_defines.hpp
@@ -39,8 +39,6 @@ namespace splash
 #define SDC_ATTR_GRID_SIZE "grid_size"
 #define SDC_ATTR_SIZE "client_size"
 #define SDC_ATTR_COMPRESSION "compression"
-
-#define DSP_DIM_MAX 3
 }
 
 #endif	/* SDC_DEFINES_H */


### PR DESCRIPTION
Reduce magic numbers by using the actual define of `DSP_DIM_MAX` where appropriate.

Even if that does not itself increase flexibility, it should already help reducing the cost if someone wants to generalize the implementation in the future (and: `DSP_DIM_MAX` was basically unused so far).