### PR TITLE
Remember HDF5 Version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -172,7 +172,14 @@ INSTALL(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/src/include/."
   PATTERN ".svn" EXCLUDE
   PATTERN ".git" EXCLUDE
   PATTERN "splash_*.h" EXCLUDE
+  PATTERN "version.hpp" EXCLUDE
 )
+
+# version.hpp file with SPLASH_HDF5_VERSION set accordingly
+configure_file( ${CMAKE_CURRENT_SOURCE_DIR}/src/include/splash/version.hpp
+                ${CMAKE_CURRENT_BINARY_DIR}/splash/version.hpp )
+INSTALL(FILES ${CMAKE_CURRENT_BINARY_DIR}/splash/version.hpp
+        DESTINATION include/splash)
 
 # install correct splash header file
 # (will be executed after the POST_BUILD copies of splash.h)

--- a/src/include/splash/version.hpp
+++ b/src/include/splash/version.hpp
@@ -34,4 +34,7 @@
 #define SPLASH_FILE_FORMAT_MAJOR 3
 #define SPLASH_FILE_FORMAT_MINOR 2
 
+/** The version of HDF5 that was used to compile splash */
+#define SPLASH_HDF5_VERSION "${HDF5_VERSION}"
+
 #endif	/* VERSION_HPP */


### PR DESCRIPTION
~~Pls do not merge this commit before #176~~
~~After the above commit was merged, I will *rebase* this pull request~~

This commit adds support to libSplash to remember the HDF5 version it was build against.

This is interesting, since depending software usually does not include `<hdf5.h>` and can not query the version of HDF5 directly via the includes.

That does not prevent users to compile HDF5 and libSplash both with shared libs and to mix various versions, but the `SPLASH_HDF_VERSION` will still point to the version Splash was originially build (and should be used) with.