### PR TITLE
Doxygen: Project Name libSplash

### DIFF
--- a/doc/Doxyfile
+++ b/doc/Doxyfile
@@ -4,7 +4,7 @@
 # Project related configuration options
 #---------------------------------------------------------------------------
 DOXYFILE_ENCODING      = UTF-8
-PROJECT_NAME           = libDataCollector
+PROJECT_NAME           = libSplash
 PROJECT_NUMBER         = 
 OUTPUT_DIRECTORY       = doxygenDoku
 CREATE_SUBDIRS         = NO


### PR DESCRIPTION
Doxygen: The project name for our `gh-pages` should be `libSplash` and not the old name (`libDataCollector`).