### PR TITLE
Close #173: Parallel Write of Global Attributes

### DIFF
--- a/src/ParallelDataCollector.cpp
+++ b/src/ParallelDataCollector.cpp
@@ -322,7 +322,7 @@ namespace splash
             throw DCException(getExceptionString("readGlobalAttribute", "this access is not permitted"));
 
         DCParallelGroup group_custom;
-        group_custom.open(handles.get(id), SDC_GROUP_CUSTOM);
+        group_custom.open(handles.get(id), PDC_GROUP_CUSTOM);
 
         try
         {
@@ -362,7 +362,7 @@ namespace splash
             throw DCException(getExceptionString("writeGlobalAttribute", "maximum dimension `ndims` is invalid"));
 
         DCParallelGroup group_custom;
-        group_custom.open(handles.get(id), SDC_GROUP_CUSTOM);
+        group_custom.open(handles.get(id), PDC_GROUP_CUSTOM);
 
         try
         {
@@ -795,7 +795,7 @@ namespace splash
 
         // the custom group holds user-specified attributes
         DCParallelGroup group;
-        group.create(handle, SDC_GROUP_CUSTOM);
+        group.create(handle, PDC_GROUP_CUSTOM);
         group.close();
 
         // the data group holds the actual simulation data

--- a/src/include/splash/ParallelDataCollector.hpp
+++ b/src/include/splash/ParallelDataCollector.hpp
@@ -33,6 +33,7 @@
 
 #include "splash/DCException.hpp"
 #include "splash/sdc_defines.hpp"
+#include "splash/pdc_defines.hpp"
 #include "splash/core/HandleMgr.hpp"
 
 namespace splash

--- a/src/include/splash/pdc_defines.hpp
+++ b/src/include/splash/pdc_defines.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Felix Schmitt
+ * Copyright 2013-2015 Felix Schmitt, Axel Huebl
  *
  * This file is part of libSplash. 
  * 
@@ -8,6 +8,7 @@
  * the GNU Lesser General Public License as published by 
  * the Free Software Foundation, either version 3 of the License, or 
  * (at your option) any later version. 
+ *
  * libSplash is distributed in the hope that it will be useful, 
  * but WITHOUT ANY WARRANTY; without even the implied warranty of 
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
@@ -24,6 +25,7 @@
 
 namespace splash
 {
+#define PDC_GROUP_CUSTOM "/"
 #define PDC_ATTR_APPEND "pdc_fillsize"
 }
 


### PR DESCRIPTION
When writing global attributes in parallel mode, one would expect them to be under the root `/` path (and to be identical for each rank).

This closes #173 and is a requirement to allow implementations to fulfill the openPMD standard.

Serial writes are not affected and still write to `/custom` (each of the ranks). A later refactoring could consider just to let one rank write to `/` here, too (and to ingore the others assuming an actual "global" == identical value).