### PR TITLE
Close #180: Write Splash Version & Format

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
  #
- # Copyright 2013-2014 Felix Schmitt, Axel Huebl
+ # Copyright 2013-2015 Felix Schmitt, Axel Huebl
  #
  # This file is part of libSplash. 
  # 
@@ -112,7 +112,7 @@ ENDIF(NOT SPLASH_RELEASE)
 SET(SPLASH_LIBS z ${HDF5_LIBRARIES})
 
 # serial or parallel version of libSplash
-SET(SPLASH_CLASSES logging DCAttribute DCDataSet DCGroup HandleMgr SerialDataCollector DomainCollector)
+SET(SPLASH_CLASSES logging DCAttribute DCDataSet DCGroup HandleMgr SerialDataCollector DomainCollector SDCHelper)
 IF(HDF5_IS_PARALLEL)
     #parallel version 
     MESSAGE(STATUS "Parallel HDF5 found. Building parallel version")

--- a/src/ParallelDataCollector.cpp
+++ b/src/ParallelDataCollector.cpp
@@ -25,8 +25,12 @@
 #include <dirent.h>
 #include <stdlib.h>
 #include <cstring>
+#include <sstream>
 
+#include "splash/version.hpp"
 #include "splash/ParallelDataCollector.hpp"
+#include "splash/basetypes/ColTypeDim.hpp"
+#include "splash/basetypes/ColTypeString.hpp"
 #include "splash/core/DCParallelDataSet.hpp"
 #include "splash/core/DCAttribute.hpp"
 #include "splash/core/DCParallelGroup.hpp"
@@ -821,10 +825,19 @@ namespace splash
         DCParallelGroup group;
         group.create(fHandle, SDC_GROUP_HEADER);
 
-        ColTypeDim dim_t;
-
         int32_t index = id;
         bool compression = enableCompression;
+        std::stringstream splashVersion;
+        splashVersion << SPLASH_VERSION_MAJOR << "."
+                      << SPLASH_VERSION_MINOR << "."
+                      << SPLASH_VERSION_PATCH;
+        std::stringstream splashFormat;
+        splashFormat << SPLASH_FILE_FORMAT_MAJOR << "."
+                     << SPLASH_FILE_FORMAT_MINOR;
+
+        ColTypeDim dim_t;
+        ColTypeString ctStringVersion(splashVersion.str().length());
+        ColTypeString ctStringFormat(splashFormat.str().length());
 
         // create master specific header attributes
         DCAttribute::writeAttribute(SDC_ATTR_MAX_ID, H5T_NATIVE_INT32,
@@ -835,6 +848,12 @@ namespace splash
 
         DCAttribute::writeAttribute(SDC_ATTR_MPI_SIZE, dim_t.getDataType(),
                 group.getHandle(), mpiTopology.getPointer());
+
+        DCAttribute::writeAttribute(SDC_ATTR_VERSION, ctStringVersion.getDataType(),
+                group.getHandle(), splashVersion.str().c_str());
+
+        DCAttribute::writeAttribute(SDC_ATTR_FORMAT, ctStringFormat.getDataType(),
+                group.getHandle(), splashFormat.str().c_str());
     }
 
     void ParallelDataCollector::openCreate(const char *filename,

--- a/src/SDCHelper.cpp
+++ b/src/SDCHelper.cpp
@@ -1,0 +1,139 @@
+/**
+ * Copyright 2013-2015 Felix Schmitt, Axel Huebl
+ *
+ * This file is part of libSplash.
+ *
+ * libSplash is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * libSplash is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libSplash.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "splash/core/SDCHelper.hpp"
+
+#include "splash/version.hpp"
+#include "splash/basetypes/ColTypeDim.hpp"
+#include "splash/basetypes/ColTypeString.hpp"
+#include "splash/core/DCAttribute.hpp"
+#include "splash/core/logging.hpp"
+
+#include <sstream>
+
+namespace splash
+{
+
+    std::string SDCHelper::getExceptionString(std::string msg)
+    {
+        return (std::string("Exception for [SDCHelper] ") + msg);
+    }
+
+    void SDCHelper::getReferenceData(const char* filename, int32_t* maxID, Dimensions *mpiSize)
+    throw (DCException)
+    {
+        log_msg(1, "loading reference data from %s", filename);
+
+        // open the file to get reference data from
+        hid_t reference_file = H5Fopen(filename, H5F_ACC_RDONLY, H5P_FILE_ACCESS_DEFAULT);
+        if (reference_file < 0)
+            throw DCException(getExceptionString(std::string("Failed to open reference file ") +
+                std::string(filename)));
+
+        // reference data is located in the header only
+        hid_t group_header = H5Gopen(reference_file, SDC_GROUP_HEADER, H5P_DEFAULT);
+        if (group_header < 0) {
+            H5Fclose(reference_file);
+            throw DCException(getExceptionString(
+                    std::string("Failed to open header group in reference file ") +
+                    std::string(filename)));
+        }
+
+        try {
+            if (maxID != NULL) {
+                DCAttribute::readAttribute(SDC_ATTR_MAX_ID,
+                        group_header, maxID);
+            }
+
+            if (mpiSize != NULL) {
+                ColTypeDim dim_t;
+                DCAttribute::readAttribute(SDC_ATTR_MPI_SIZE,
+                        group_header, mpiSize->getPointer());
+            }
+
+        } catch (DCException attr_exception) {
+            H5Fclose(reference_file);
+            throw DCException(getExceptionString(
+                    std::string("Failed to read attributes from reference file ") +
+                    std::string(filename)));
+        }
+
+        // cleanup
+        H5Gclose(group_header);
+        H5Fclose(reference_file);
+    }
+
+    void SDCHelper::writeHeader(hid_t file, Dimensions mpiPosition,
+            int32_t *maxID, bool *enableCompression, Dimensions *mpiSize,
+            bool master)
+    throw (DCException)
+    {
+        // create group for header information (position, grid size, ...)
+        hid_t group_header = H5Gcreate(file, SDC_GROUP_HEADER, H5P_LINK_CREATE_DEFAULT,
+                H5P_GROUP_CREATE_DEFAULT, H5P_GROUP_ACCESS_DEFAULT);
+        if (group_header < 0)
+            throw DCException(getExceptionString("Failed to create header group in reference file"));
+
+        try {
+            std::stringstream splashVersion;
+            splashVersion << SPLASH_VERSION_MAJOR << "."
+                          << SPLASH_VERSION_MINOR << "."
+                          << SPLASH_VERSION_PATCH;
+            std::stringstream splashFormat;
+            splashFormat << SPLASH_FILE_FORMAT_MAJOR << "."
+                         << SPLASH_FILE_FORMAT_MINOR;
+
+            ColTypeDim dim_t;
+            ColTypeString ctStringVersion(splashVersion.str().length());
+            ColTypeString ctStringFormat(splashFormat.str().length());
+
+            // create master specific header attributes
+            if (master) {
+                DCAttribute::writeAttribute(SDC_ATTR_MAX_ID, H5T_NATIVE_INT32,
+                        group_header, maxID);
+            } else {
+                DCAttribute::writeAttribute(SDC_ATTR_MPI_POSITION, dim_t.getDataType(),
+                        group_header, mpiPosition.getPointer());
+            }
+
+            DCAttribute::writeAttribute(SDC_ATTR_COMPRESSION, H5T_NATIVE_HBOOL,
+                    group_header, enableCompression);
+
+            DCAttribute::writeAttribute(SDC_ATTR_MPI_SIZE, dim_t.getDataType(),
+                    group_header, mpiSize->getPointer());
+
+            DCAttribute::writeAttribute(SDC_ATTR_VERSION, ctStringVersion.getDataType(),
+                    group_header, splashVersion.str().c_str());
+
+            DCAttribute::writeAttribute(SDC_ATTR_FORMAT, ctStringFormat.getDataType(),
+                    group_header, splashFormat.str().c_str());
+
+        } catch (DCException attr_error) {
+            throw DCException(getExceptionString(
+                std::string("Failed to write header attribute in reference file. Error was: ") +
+                std::string(attr_error.what())));
+        }
+
+        H5Gclose(group_header);
+    }
+
+} /* namespace splash */

--- a/src/include/splash/core/SDCHelper.hpp
+++ b/src/include/splash/core/SDCHelper.hpp
@@ -1,34 +1,33 @@
 /**
- * Copyright 2013 Felix Schmitt
+ * Copyright 2013-2015 Felix Schmitt, Axel Huebl
  *
- * This file is part of libSplash. 
- * 
- * libSplash is free software: you can redistribute it and/or modify 
- * it under the terms of of either the GNU General Public License or 
- * the GNU Lesser General Public License as published by 
- * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
- * libSplash is distributed in the hope that it will be useful, 
- * but WITHOUT ANY WARRANTY; without even the implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
- * GNU General Public License and the GNU Lesser General Public License 
- * for more details. 
- * 
- * You should have received a copy of the GNU General Public License 
- * and the GNU Lesser General Public License along with libSplash. 
- * If not, see <http://www.gnu.org/licenses/>. 
- */ 
- 
-
+ * This file is part of libSplash.
+ *
+ * libSplash is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * libSplash is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libSplash.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
 
 #ifndef SDCHELPER_H
-#define	SDCHELPER_H
+#define SDCHELPER_H
 
-#include "splash/basetypes/ColTypeDim.hpp"
 #include "splash/sdc_defines.hpp"
-#include "splash/core/DCAttribute.hpp"
-#include "splash/core/logging.hpp"
+#include "splash/Dimensions.hpp"
 #include "splash/DCException.hpp"
+
+#include <string>
 
 namespace splash
 {
@@ -41,10 +40,7 @@ namespace splash
     private:
         SDCHelper();
 
-        static std::string getExceptionString(std::string msg)
-        {
-            return (std::string("Exception for [SDCHelper] ") + msg);
-        }
+        static std::string getExceptionString(std::string msg);
 
     public:
 
@@ -56,48 +52,7 @@ namespace splash
          * @param mpiSize pointer to hold size of mpi grid. can be NULL
          */
         static void getReferenceData(const char* filename, int32_t* maxID, Dimensions *mpiSize)
-        throw (DCException)
-        {
-            log_msg(1, "loading reference data from %s", filename);
-
-            // open the file to get reference data from
-            hid_t reference_file = H5Fopen(filename, H5F_ACC_RDONLY, H5P_FILE_ACCESS_DEFAULT);
-            if (reference_file < 0)
-                throw DCException(getExceptionString(std::string("Failed to open reference file ") +
-                    std::string(filename)));
-
-            // reference data is located in the header only
-            hid_t group_header = H5Gopen(reference_file, SDC_GROUP_HEADER, H5P_DEFAULT);
-            if (group_header < 0) {
-                H5Fclose(reference_file);
-                throw DCException(getExceptionString(
-                        std::string("Failed to open header group in reference file ") +
-                        std::string(filename)));
-            }
-
-            try {
-                if (maxID != NULL) {
-                    DCAttribute::readAttribute(SDC_ATTR_MAX_ID,
-                            group_header, maxID);
-                }
-
-                if (mpiSize != NULL) {
-                    ColTypeDim dim_t;
-                    DCAttribute::readAttribute(SDC_ATTR_MPI_SIZE,
-                            group_header, mpiSize->getPointer());
-                }
-
-            } catch (DCException attr_exception) {
-                H5Fclose(reference_file);
-                throw DCException(getExceptionString(
-                        std::string("Failed to read attributes from reference file ") +
-                        std::string(filename)));
-            }
-
-            // cleanup
-            H5Gclose(group_header);
-            H5Fclose(reference_file);
-        }
+        throw (DCException);
 
         /**
          * Writes header information to file.
@@ -112,42 +67,8 @@ namespace splash
         static void writeHeader(hid_t file, Dimensions mpiPosition,
                 int32_t *maxID, bool *enableCompression, Dimensions *mpiSize,
                 bool master = false)
-        throw (DCException)
-        {
-            // create group for header information (position, grid size, ...)
-            hid_t group_header = H5Gcreate(file, SDC_GROUP_HEADER, H5P_LINK_CREATE_DEFAULT,
-                    H5P_GROUP_CREATE_DEFAULT, H5P_GROUP_ACCESS_DEFAULT);
-            if (group_header < 0)
-                throw DCException(getExceptionString("Failed to create header group in reference file"));
-
-            try {
-                ColTypeDim dim_t;
-
-                // create master specific header attributes
-                if (master) {
-                    DCAttribute::writeAttribute(SDC_ATTR_MAX_ID, H5T_NATIVE_INT32,
-                            group_header, maxID);
-                } else {
-                    DCAttribute::writeAttribute(SDC_ATTR_MPI_POSITION, dim_t.getDataType(),
-                            group_header, mpiPosition.getPointer());
-                }
-
-                DCAttribute::writeAttribute(SDC_ATTR_COMPRESSION, H5T_NATIVE_HBOOL,
-                        group_header, enableCompression);
-
-                DCAttribute::writeAttribute(SDC_ATTR_MPI_SIZE, dim_t.getDataType(),
-                        group_header, mpiSize->getPointer());
-
-            } catch (DCException attr_error) {
-                throw DCException(getExceptionString(
-                        std::string("Failed to write header attribute in reference file. Error was: ") +
-                        std::string(attr_error.what())));
-            }
-
-            H5Gclose(group_header);
-        }
+        throw (DCException);
     };
 }
 
 #endif	/* SDCHELPER_H */
-

--- a/src/include/splash/sdc_defines.hpp
+++ b/src/include/splash/sdc_defines.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Felix Schmitt
+ * Copyright 2013-2015 Felix Schmitt, Axel Huebl
  *
  * This file is part of libSplash. 
  * 
@@ -8,6 +8,7 @@
  * the GNU Lesser General Public License as published by 
  * the Free Software Foundation, either version 3 of the License, or 
  * (at your option) any later version. 
+ *
  * libSplash is distributed in the hope that it will be useful, 
  * but WITHOUT ANY WARRANTY; without even the implied warranty of 
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
@@ -39,6 +40,8 @@ namespace splash
 #define SDC_ATTR_GRID_SIZE "grid_size"
 #define SDC_ATTR_SIZE "client_size"
 #define SDC_ATTR_COMPRESSION "compression"
+#define SDC_ATTR_VERSION "splashVersion"
+#define SDC_ATTR_FORMAT "splashFormat"
 }
 
 #endif	/* SDC_DEFINES_H */

--- a/tests/readBoolChar.py
+++ b/tests/readBoolChar.py
@@ -26,6 +26,12 @@ import numpy as np
 
 # bool compatible data sets ###################################################
 f = h5py.File("h5/testWriteRead_0_0_0.h5", "r")
+
+# print version
+print("Splash version: {}".format(f["header"].attrs["splashVersion"]))
+print("Splash format: {}".format(f["header"].attrs["splashFormat"]))
+
+# read data set
 data = f["data/10/deep/folders/data_bool"]
 
 len = data.size


### PR DESCRIPTION
Closes issue #180: create two string attributes under `/header/` `splashVersion` and `splashFormat` so people know what kind of files they are dealing with.