### PR TITLE
close #154: add warning to test run scripts if no build directory is given

### DIFF
--- a/tests/run_parallel_tests
+++ b/tests/run_parallel_tests
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+if [ $# -eq 0 ]; then
+    echo "  WARNING:"
+    echo "    No path for build director was given."
+    echo "    Will use \"build\" instead."
+fi
+
 dir=${1:-build}
 
 rm -rf $dir/h5

--- a/tests/run_tests
+++ b/tests/run_tests
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+if [ $# -eq 0 ]; then
+    echo "  WARNING:"
+    echo "    No path for build director was given."
+    echo "    Will use \"build\" instead."
+fi
+
 dir=${1:-build}
 
 rm -rf $dir/h5


### PR DESCRIPTION
This pull request adds a test to check if command line arguments are given for `run_tests` and `run_parallel_tests`. If no argument is given a warning is printed and the prevoisly defined default is used.

This closes issue #154. 

@ax3l Please have a look.