### PR TITLE
Bool: CAPS Enum Labels for h5py

### DIFF
--- a/src/include/splash/basetypes/ColTypeBool.hpp
+++ b/src/include/splash/basetypes/ColTypeBool.hpp
@@ -40,7 +40,7 @@ public:
         // this is a h5py compatible implementation for bool, see:
         //   http://docs.h5py.org/en/latest/faq.html
         this->type = H5Tenum_create(H5T_NATIVE_INT8);
-        const char *names[2] = {"true", "false"};
+        const char *names[2] = {"TRUE", "FALSE"};
         const int64_t val[2] = {1, 0};
         H5Tenum_insert(this->type, names[0], &val[0]);
         H5Tenum_insert(this->type, names[1], &val[1]);

--- a/src/include/splash/version.hpp
+++ b/src/include/splash/version.hpp
@@ -32,7 +32,7 @@
  *  changes in the minor number have to be backwards compatible
  */
 #define SPLASH_FILE_FORMAT_MAJOR 3
-#define SPLASH_FILE_FORMAT_MINOR 2
+#define SPLASH_FILE_FORMAT_MINOR 3
 
 /** The version of HDF5 that was used to compile splash */
 #define SPLASH_HDF5_VERSION "${HDF5_VERSION}"

--- a/tests/readBoolChar.py
+++ b/tests/readBoolChar.py
@@ -33,6 +33,10 @@ print("Splash format: {}".format(f["header"].attrs["splashFormat"]))
 
 # read data set
 data = f["data/10/deep/folders/data_bool"]
+print(data, type(data), data.dtype)
+
+if not type(data[0,0,0]) is np.bool_:
+    exit(1)
 
 len = data.size
 data1d = data[:,:,:].reshape(len)


### PR DESCRIPTION
Else it does not identify those as `bool_` but as `int8`.
Regression for #153 (still in `dev`).

`h5py` representation since #153 (example for a `False` value):
```
scalar attribute: (1, <type 'numpy.int8'>)

data set: <HDF5 dataset "data_bool": shape (7, 7, 7), type "|i1">,
          <class 'h5py._hl.dataset.Dataset'>,
          dtype([(({'vals': {'true': 1, 'false': 0}}, 'enum'), 'i1')])
```

and now (same enum but with different label):
```
scalar attribute: False, <type 'numpy.bool_'>

data set: <HDF5 dataset "data_bool": shape (7, 7, 7), type "|b1">,
          <class 'h5py._hl.dataset.Dataset'>,
          dtype('bool')
```

Increases format by a minor since the structure is still the same but the identification in `h5py` is improved (and it is still not in a stable release).

### To Do

- [x] will add a test in travis