### PR TITLE
Close #184 Compression Header as Bool

### DIFF
--- a/src/ParallelDataCollector.cpp
+++ b/src/ParallelDataCollector.cpp
@@ -29,8 +29,7 @@
 
 #include "splash/version.hpp"
 #include "splash/ParallelDataCollector.hpp"
-#include "splash/basetypes/ColTypeDim.hpp"
-#include "splash/basetypes/ColTypeString.hpp"
+#include "splash/basetypes/basetypes.hpp"
 #include "splash/core/DCParallelDataSet.hpp"
 #include "splash/core/DCAttribute.hpp"
 #include "splash/core/DCParallelGroup.hpp"
@@ -835,15 +834,17 @@ namespace splash
         splashFormat << SPLASH_FILE_FORMAT_MAJOR << "."
                      << SPLASH_FILE_FORMAT_MINOR;
 
+        ColTypeInt32 ctInt32;
+        ColTypeBool ctBool;
         ColTypeDim dim_t;
         ColTypeString ctStringVersion(splashVersion.str().length());
         ColTypeString ctStringFormat(splashFormat.str().length());
 
         // create master specific header attributes
-        DCAttribute::writeAttribute(SDC_ATTR_MAX_ID, H5T_NATIVE_INT32,
+        DCAttribute::writeAttribute(SDC_ATTR_MAX_ID, ctInt32.getDataType(),
                 group.getHandle(), &index);
 
-        DCAttribute::writeAttribute(SDC_ATTR_COMPRESSION, H5T_NATIVE_HBOOL,
+        DCAttribute::writeAttribute(SDC_ATTR_COMPRESSION, ctBool.getDataType(),
                 group.getHandle(), &compression);
 
         DCAttribute::writeAttribute(SDC_ATTR_MPI_SIZE, dim_t.getDataType(),

--- a/src/SDCHelper.cpp
+++ b/src/SDCHelper.cpp
@@ -23,8 +23,7 @@
 #include "splash/core/SDCHelper.hpp"
 
 #include "splash/version.hpp"
-#include "splash/basetypes/ColTypeDim.hpp"
-#include "splash/basetypes/ColTypeString.hpp"
+#include "splash/basetypes/basetypes.hpp"
 #include "splash/core/DCAttribute.hpp"
 #include "splash/core/logging.hpp"
 
@@ -102,20 +101,22 @@ namespace splash
             splashFormat << SPLASH_FILE_FORMAT_MAJOR << "."
                          << SPLASH_FILE_FORMAT_MINOR;
 
+            ColTypeInt32 ctInt32;
+            ColTypeBool ctBool;
             ColTypeDim dim_t;
             ColTypeString ctStringVersion(splashVersion.str().length());
             ColTypeString ctStringFormat(splashFormat.str().length());
 
             // create master specific header attributes
             if (master) {
-                DCAttribute::writeAttribute(SDC_ATTR_MAX_ID, H5T_NATIVE_INT32,
+                DCAttribute::writeAttribute(SDC_ATTR_MAX_ID, ctInt32.getDataType(),
                         group_header, maxID);
             } else {
                 DCAttribute::writeAttribute(SDC_ATTR_MPI_POSITION, dim_t.getDataType(),
                         group_header, mpiPosition.getPointer());
             }
 
-            DCAttribute::writeAttribute(SDC_ATTR_COMPRESSION, H5T_NATIVE_HBOOL,
+            DCAttribute::writeAttribute(SDC_ATTR_COMPRESSION, ctBool.getDataType(),
                     group_header, enableCompression);
 
             DCAttribute::writeAttribute(SDC_ATTR_MPI_SIZE, dim_t.getDataType(),

--- a/src/SerialDataCollector.cpp
+++ b/src/SerialDataCollector.cpp
@@ -29,6 +29,8 @@
 
 #include "splash/SerialDataCollector.hpp"
 
+#include "splash/basetypes/basetypes.hpp"
+
 #include "splash/core/DCAttribute.hpp"
 #include "splash/core/DCDataSet.hpp"
 #include "splash/core/DCGroup.hpp"
@@ -163,7 +165,8 @@ namespace splash
             // write number of iterations
             try
             {
-                DCAttribute::writeAttribute(SDC_ATTR_MAX_ID, H5T_NATIVE_INT32,
+                ColTypeInt32 ctInt32;
+                DCAttribute::writeAttribute(SDC_ATTR_MAX_ID, ctInt32.getDataType(),
                         group.getHandle(), &maxID);
             } catch (DCException e)
             {


### PR DESCRIPTION
### Description

Close #184 by using the new `h5py` compatible bool type for our `/header/compression` attribute.

Increases the format by a minor - can be merged directly **after** #198 (purely informative argument that has no influence on transparent reads of compressed or uncompressed data sets; since last stable release already a major format increase).

Also changes internally to use our `ColTypeInt32` instead of the native type for `SDC_ATTR_MAX_ID` which is not changing the format since they are identical (or at least `H5T_NATIVE_INT32` ([ANSI C9x](https://www.hdfgroup.org/HDF5/doc/RM/PredefDTypes.html)) and [H5T_INTEL_I32](https://github.com/ax3l/libSplash/blob/018f7c493e543cd040d5613ed0709ab81ddebfc6/src/include/splash/basetypes/basetypes_atomic.hpp#L57) seem to be identical).

### Tests

`h5diff` output:
```bash
$ h5diff -c h5/testWriteRead_0_0_0.h5 ../build/h5/testWriteRead_0_0_0.h5                                                                                                                 
[...]
Not comparable: <compression> is of class H5T_INTEGER and <compression> is of class H5T_ENUM

attribute: <splashFormat of </header>> and <splashFormat of </header>>
1 differences found
```

`h5dump -A h5/testWriteRead_0_0_0.h5`:
*old*:
```
[...]
   GROUP "header" {
      ATTRIBUTE "compression" {
         DATATYPE  H5T_STD_I32LE
         DATASPACE  SCALAR
         DATA {
         (0): 0
         }
      }
[...]
   }
[...]
```

*new* (all-CAPS labels depend on #198):
```
[...]
   GROUP "header" {
      ATTRIBUTE "compression" {
         DATATYPE  H5T_ENUM {
            H5T_STD_I8LE;
            "TRUE"             1;
            "FALSE"            0;
         }
         DATASPACE  SCALAR
         DATA {
         (0): false
         }
      }
[...]
   }
[...]
```

**Python**
via
```bash
python -c 'import h5py as h5; f=h5.File("h5/testWriteRead_0_0_0.h5"); c=f["header"].attrs["compression"]; print( c, type(c) )'
```

__uncompressed__: *new* (`False, <type 'numpy.bool_'>`) and *old* both (`(0, <type 'numpy.int32'>)`)
__compressed__ `[1]`: *new* (`True, <type 'numpy.bool_'>`) and *old* (`1, <type 'numpy.int32'>`, but value [can be arbitrary](https://github.com/ComputationalRadiationPhysics/libSplash/issues/184#issuecomment-129605660))

### Notes

`[1]` compressed output in tests used patch:
```patch
diff --git a/tests/SimpleDataTest.cpp b/tests/SimpleDataTest.cpp
index 9907663..614282a 100644
--- a/tests/SimpleDataTest.cpp
+++ b/tests/SimpleDataTest.cpp
@@ -72,6 +72,7 @@ bool SimpleDataTest::subtestWriteRead(Dimensions gridSize, Dimensions borderSize
     // write data to file
     DataCollector::FileCreationAttr fileCAttr;
     DataCollector::initFileCreationAttr(fileCAttr);
+    fileCAttr.enableCompression = true;
     dataCollector->open(HDF5_FILE, fileCAttr);
 
     // initial part of the test: data is written to the file, once with and once
```

and `bool_` representation depends on #198.