### PR TITLE
Fix Public Wshadow Warnings

### DIFF
--- a/src/include/splash/Selection.hpp
+++ b/src/include/splash/Selection.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2014 Felix Schmitt
+ * Copyright 2014-2015 Felix Schmitt, Axel Huebl
  *
  * This file is part of libSplash.
  *
@@ -8,6 +8,7 @@
  * the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
+ *
  * libSplash is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -39,12 +40,12 @@ namespace splash
 
         /**
          * Constructor
-         * 
-         * @param size size of src buffer (select complete buffer)
+         *
+         * @param size_ size of src buffer (select complete buffer)
          */
-        Selection(Dimensions size) :
-        size(size),
-        count(size),
+        Selection(Dimensions size_) :
+        size(size_),
+        count(size_),
         offset(0, 0, 0),
         stride(1, 1, 1)
         {
@@ -52,16 +53,16 @@ namespace splash
         }
 
         /**
-         * Constructor 
-         * 
-         * @param size size of src buffer
-         * @param count size of selection within src buffer
-         * @param offset offset of selection within src buffer
+         * Constructor
+         *
+         * @param size_ size of src buffer
+         * @param count_ size of selection within src buffer
+         * @param offset_ offset of selection within src buffer
          */
-        Selection(Dimensions size, Dimensions count, Dimensions offset) :
-        size(size),
-        count(count),
-        offset(offset),
+        Selection(Dimensions size_, Dimensions count_, Dimensions offset_) :
+        size(size_),
+        count(count_),
+        offset(offset_),
         stride(1, 1, 1)
         {
 
@@ -69,24 +70,24 @@ namespace splash
 
         /**
          * Constructor
-         * 
-         * @param size size of src buffer
-         * @param count size of selection within src buffer
-         * @param offset offset of selection within src buffer
-         * @param stride stride of selection within src buffer
+         *
+         * @param size_ size of src buffer
+         * @param count_ size of selection within src buffer
+         * @param offset_ offset of selection within src buffer
+         * @param stride_ stride of selection within src buffer
          */
-        Selection(Dimensions size, Dimensions count, Dimensions offset, Dimensions stride) :
-        size(size),
-        count(count),
-        offset(offset),
-        stride(stride)
+        Selection(Dimensions size_, Dimensions count_, Dimensions offset_, Dimensions stride_) :
+        size(size_),
+        count(count_),
+        offset(offset_),
+        stride(stride_)
         {
 
         }
-        
+
         /**
          * Swap dimensions
-         * 
+         *
          * @param ndims number of dimensions of this selection
          */
         void swapDims(uint32_t ndims)
@@ -96,7 +97,7 @@ namespace splash
             offset.swapDims(ndims);
             stride.swapDims(ndims);
         }
-        
+
         /**
          * Create a string representation of this selection
          * 
@@ -122,4 +123,3 @@ namespace splash
 }
 
 #endif	/* SELECTION_HPP */
-

--- a/src/include/splash/domains/Domain.hpp
+++ b/src/include/splash/domains/Domain.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2014 Felix Schmitt
+ * Copyright 2013-2015 Felix Schmitt, Axel Huebl
  *
  * This file is part of libSplash. 
  * 
@@ -7,7 +7,8 @@
  * it under the terms of of either the GNU General Public License or 
  * the GNU Lesser General Public License as published by 
  * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
+ * (at your option) any later version.
+ *
  * libSplash is distributed in the hope that it will be useful, 
  * but WITHOUT ANY WARRANTY; without even the implied warranty of 
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
@@ -18,8 +19,6 @@
  * and the GNU Lesser General Public License along with libSplash. 
  * If not, see <http://www.gnu.org/licenses/>. 
  */
-
-
 
 #ifndef DOMAIN_HPP
 #define	DOMAIN_HPP
@@ -53,13 +52,13 @@ namespace splash
 
         /**
          * Constructor.
-         * 
-         * @param offset Offset of this domain in the parent domain.
-         * @param size Size of this domain in every dimension.
+         *
+         * @param offset_ Offset of this domain in the parent domain.
+         * @param size_ Size of this domain in every dimension.
          */
-        Domain(Dimensions offset, Dimensions size) :
-        offset(offset),
-        size(size)
+        Domain(Dimensions offset_, Dimensions size_) :
+        offset(offset_),
+        size(size_)
         {
 
         }
@@ -177,4 +176,3 @@ namespace splash
 }
 
 #endif	/* DOMAIN_HPP */
-

--- a/src/include/splash/domains/DomainData.hpp
+++ b/src/include/splash/domains/DomainData.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2014 Felix Schmitt
+ * Copyright 2013-2015 Felix Schmitt, Axel Huebl
  *
  * This file is part of libSplash. 
  * 
@@ -7,7 +7,8 @@
  * it under the terms of of either the GNU General Public License or 
  * the GNU Lesser General Public License as published by 
  * the Free Software Foundation, either version 3 of the License, or 
- * (at your option) any later version. 
+ * (at your option) any later version.
+ *
  * libSplash is distributed in the hope that it will be useful, 
  * but WITHOUT ANY WARRANTY; without even the implied warranty of 
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
@@ -18,8 +19,6 @@
  * and the GNU Lesser General Public License along with libSplash. 
  * If not, see <http://www.gnu.org/licenses/>. 
  */
-
-
 
 #ifndef DOMAINDATA_HPP
 #define	DOMAINDATA_HPP
@@ -61,20 +60,20 @@ namespace splash
         /**
          * Constructor.
          * Allocates enough memory to hold 'elements' data of 'type'.
-         * 
-         * @param domain The underlying Domain.
-         * @param elements Number of data elements in every dimension.
-         * @param datatypeSize Size of each element in bytes.
-         * @param datatype Internal representation of HDF5 datatype.
+         *
+         * @param domain_ The underlying Domain.
+         * @param elements_ Number of data elements in every dimension.
+         * @param datatypeSize_ Size of each element in bytes.
+         * @param datatype_ Internal representation of HDF5 datatype.
          */
-        DomainData(const Domain& domain, const Dimensions elements,
-                size_t datatypeSize, DCDataType datatype) :
-        Domain(domain),
-        elements(elements),
+        DomainData(const Domain& domain_, const Dimensions elements_,
+                size_t datatypeSize_, DCDataType datatype_) :
+        Domain(domain_),
+        elements(elements_),
         data(NULL),
         loadingReference(NULL),
-        datatype(datatype),
-        datatypeSize(datatypeSize)
+        datatype(datatype_),
+        datatypeSize(datatypeSize_)
         {
             data = new uint8_t[datatypeSize * elements.getScalarSize()];
             assert(data != NULL);
@@ -232,4 +231,3 @@ namespace splash
 }
 
 #endif	/* DOMAINDATA_HPP */
-


### PR DESCRIPTION
This commit fixes warnings in public header files caused by libSplash in external projects (as in [PIConGPU](https://github.com/ComputationalRadiationPhysics/picongpu/issues/1042)) when compiled with `-Wshadow`.

Since the affected classes are used as structs (purely public members) refining those in a `member_m` naming scheme would be more intrusive then changing the naming in their contructors.

Generally it is pretty annoying that `-Wshadow` also calls out contructors but keeping those clean allows to find more serious bugs with it.

Related to #190 but does not yet fix the Splash compile itself (non-public headers and implementations).