### PR TITLE
Close #157 Iteration in Doxygen

### DIFF
--- a/src/include/splash/DataCollector.hpp
+++ b/src/include/splash/DataCollector.hpp
@@ -245,15 +245,18 @@ namespace splash
                 const void *buf) = 0;
 
         /**
-         * Removes a simulation step from the HDF5 file.
-         * 
+         * Removes a simulation iteration from the HDF5 file.
+         *
+         * Recursively removes all datasets and attributes within
+         * the iteration.
+         *
          * @param id ID to remove.
          */
         virtual void remove(int32_t id) = 0;
 
         /**
          * Removes a dataset from a HDF5 file.
-         * 
+         *
          * @param id ID holding the dataset to be removed.
          * @param name Name of the dataset to be removed.
          */
@@ -262,10 +265,10 @@ namespace splash
 
         /**
          * Creates an object reference to an existing dataset in the same HDF5 file.
-         * 
+         *
          * @param srcID ID of the iteration holding the source dataset.
          * @param srcName Name of the existing source dataset.
-         * @param dstID ID of the simulation step holding the created reference dataset.
+         * @param dstID ID of the simulation iteration holding the created reference dataset.
          * If this group does not exist, it is created.
          * @param dstName Name of the created reference.
          */
@@ -276,10 +279,10 @@ namespace splash
 
         /**
          * Creates a dataset region reference to an existing dataset in the same HDF5 file.
-         * 
+         *
          * @param srcID ID of the iteration holding the source dataset.
          * @param srcName Name of the existing source dataset.
-         * @param dstID ID of the simulation step holding the created reference dataset.
+         * @param dstID ID of the simulation iteration holding the created reference dataset.
          * If this group does not exist, it is created.
          * @param dstName Name of the created reference.
          * @param count Number of elements referenced from the source dataset.

--- a/src/include/splash/sdc_defines.hpp
+++ b/src/include/splash/sdc_defines.hpp
@@ -34,7 +34,6 @@ namespace splash
 #define SDC_ATTR_DIM_LOCAL "dim_local"
 #define SDC_ATTR_DIM_GLOBAL "dim_global"
 #define SDC_ATTR_MAX_ID "max_id"
-#define SDC_ATTR_ID_STEP "id_step"
 #define SDC_ATTR_MPI_POSITION "mpi_position"
 #define SDC_ATTR_MPI_SIZE "mpi_size"
 #define SDC_ATTR_GRID_SIZE "grid_size"


### PR DESCRIPTION
Close #157 Use the term `iteration` instead of (time) `step` also in last doxygen strings that were missing.

Removes also an unused define.