### PR TITLE
Close #14 Add PDC Example

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -100,6 +100,43 @@ endif(Splash_FOUND)
 # target_link_libraries(yourBinary ${LIBS})
 ```
 
+Examples
+--------
+
+To build the examples in the `examples` subdirectory, just run the following
+commands in an empty build directory:
+
+```bash
+cmake -DWITH_MPI=ON <yourPathTo>/libSplash/examples/
+make
+```
+
+`WITH_MPI` will enable/disable MPI based tests. Parallel libSplash examples
+will require a parallel HDF5 install.
+
+```bash
+# MPI based serial (posix) writer
+#   -> creates four h5_X_Y_Z.h5 files
+#      depending on MPI topology;
+#      iterations are appended in these files
+mpiexec -n 4 ./domain_write_mpi.cpp.out h5 2 2 1
+
+# MPI based serial (posix) reader
+#    -> reads h5_X_Y_Z.h5 files
+mpiexec -n 4 ./domain_read_mpi.cpp.out h5 2 2 1
+# serial (posix) reader
+#   -> reads h5_X_Y_Z.h5 files
+./domain_read.cpp.out h5
+
+# MPI based parallel (MPI-I/O) writer
+#   -> creates ph5_10.h5 (iteration = 10);
+#      each iteration creates a new file but
+#      MPI parallel chunks of the same iteration
+#      are aggregated to one file
+mpiexec -n 4 ./parallel_domain_write.cpp.out ph5 2 2 1
+```
+
+
 Tests
 -----
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,19 +1,19 @@
+ # Copyright 2013-2015 Felix Schmitt, Axel Huebl
  #
- # Copyright 2013 Felix Schmitt
+ # This file is part of libSplash.
  #
- # This file is part of libSplash. 
- # 
  # libSplash is free software: you can redistribute it and/or modify 
  # it under the terms of of either the GNU General Public License or 
  # the GNU Lesser General Public License as published by 
  # the Free Software Foundation, either version 3 of the License, or 
- # (at your option) any later version. 
+ # (at your option) any later version.
+ #
  # libSplash is distributed in the hope that it will be useful, 
  # but WITHOUT ANY WARRANTY; without even the implied warranty of 
  # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
  # GNU General Public License and the GNU Lesser General Public License 
  # for more details. 
- # 
+ #
  # You should have received a copy of the GNU General Public License 
  # and the GNU Lesser General Public License along with libSplash. 
  # If not, see <http://www.gnu.org/licenses/>.
@@ -40,6 +40,7 @@ OPTION(WITH_MPI "build MPI examples" OFF)
 
 SET(EXAMPLES domain_read/domain_read)
 SET(MPI_EXAMPLES domain_read/domain_read_mpi domain_write/domain_write_mpi)
+SET(PARALLEL_EXAMPLES parallel_domain_write/parallel_domain_write)
 
 FOREACH(EXAMPLE_NAME ${EXAMPLES})
     SET(EXAMPLE_FILES "${EXAMPLE_FILES};${EXAMPLE_NAME}.cpp")
@@ -47,6 +48,9 @@ ENDFOREACH()
 
 FOREACH(EXAMPLE_NAME ${MPI_EXAMPLES})
     SET(MPI_EXAMPLE_FILES "${MPI_EXAMPLE_FILES};${EXAMPLE_NAME}.cpp")
+ENDFOREACH()
+FOREACH(PARALLEL_EXAMPLE_NAME ${PARALLEL_EXAMPLES})
+    SET(PARALLEL_EXAMPLE_FILES "${PARALLEL_EXAMPLE_FILES};${PARALLEL_EXAMPLE_NAME}.cpp")
 ENDFOREACH()
 
 #-------------------------------------------------------------------------------
@@ -102,6 +106,10 @@ ENDFOREACH()
 
 # build all MPI examples
 IF(WITH_MPI)
+    # add parallel examples
+    IF(HDF5_IS_PARALLEL)
+        SET(MPI_EXAMPLE_FILES ${MPI_EXAMPLE_FILES} ${PARALLEL_EXAMPLE_FILES})
+    ENDIF(HDF5_IS_PARALLEL)
     MESSAGE(STATUS "Building MPI examples")
     FOREACH(EXAMPLE_FILE ${MPI_EXAMPLE_FILES})
         GET_FILENAME_COMPONENT(FILE ${EXAMPLE_FILE} NAME)

--- a/examples/parallel_domain_write/parallel_domain_write.cpp
+++ b/examples/parallel_domain_write/parallel_domain_write.cpp
@@ -1,0 +1,124 @@
+/**
+ * Copyright 2013-2015 Felix Schmitt, Axel Huebl
+ *
+ * This file is part of libSplash.
+ *
+ * libSplash is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * libSplash is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libSplash.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <mpi.h>
+
+#include <iostream>
+#include <string>
+#include <stdlib.h>
+
+#include "splash/splash.h"
+
+using namespace splash;
+
+/**
+ * This libSplash example demonstrates on how to use the ParallelDomainCollector class
+ * to write a single, aggregated libSplash file with parallel HDF5.
+ *
+ * The program expects the base part to a libSplash filename and the MPI process topology.
+ */
+
+void indexToPos(int index, Dimensions mpiSize, Dimensions &mpiPos)
+{
+    mpiPos[2] = index % mpiSize[2];
+    mpiPos[1] = (index / mpiSize[2]) % mpiSize[1];
+    mpiPos[0] = index / (mpiSize[1] * mpiSize[2]);
+}
+
+int main(int argc, char **argv)
+{
+    MPI_Init(&argc, &argv);
+
+    if (argc < 5)
+    {
+        std::cout << "Usage: " << argv[0] << " <libsplash-file-base> <x> <y> <z>" << std::endl;
+        return -1;
+    }
+
+    int mpi_rank, mpi_size;
+    MPI_Comm_rank(MPI_COMM_WORLD, &mpi_rank);
+    MPI_Comm_size(MPI_COMM_WORLD, &mpi_size);
+
+    /* libSplash filename */
+    std::string filename;
+    filename.assign(argv[1]);
+
+    Dimensions mpiTopology(atoi(argv[2]), atoi(argv[3]), atoi(argv[4]));
+    Dimensions mpiPosition;
+    if (mpi_size != mpiTopology.getScalarSize())
+    {
+        std::cout << "MPI processes and topology do not match!" << std::endl;
+        return -1;
+    }
+
+    indexToPos(mpi_rank, mpiTopology, mpiPosition);
+
+    /* create ParallelDomainCollector */
+    {
+    ParallelDomainCollector pdc(MPI_COMM_WORLD, MPI_INFO_NULL,
+        mpiTopology, 100 );
+    DataCollector::FileCreationAttr fAttr;
+    DataCollector::initFileCreationAttr(fAttr);
+
+    fAttr.mpiPosition.set(mpiPosition);
+
+    pdc.open(filename.c_str(), fAttr);
+
+    /* create data for writing */
+    Dimensions localGridSize(10, 20, 5);
+
+    ColTypeFloat ctFloat;
+    float *data = new float[localGridSize.getScalarSize()];
+    memset(data, 1, sizeof(float) * localGridSize.getScalarSize());
+
+    /* where our example logically starts */
+    Dimensions globalDomainOffset(100, 100, 100);
+    /* where this process logically starts */
+    Dimensions localDomainOffset(mpiPosition * localGridSize);
+
+    /**
+     * See your local Doxygen documentation or online at
+     * https://computationalradiationphysics.github.io/libSplash/classsplash_1_1_parallel_domain_collector.html
+     * for more information on this interface.
+     **/
+    pdc.writeDomain(10,                   /* iteration */
+            ctFloat,                      /* data type */
+            localGridSize.getDims(),      /* number of dimensions (here 3) */
+            Selection(localGridSize),     /* data size of this process */
+            "float_data",                 /* name of dataset */
+            Domain(localDomainOffset,     /* logical offset of the data of this process */
+            localGridSize),               /* logical size of the data of this process
+                                           * must match actual data size for grids */
+            Domain(globalDomainOffset,    /* logical start of the data of all processes */
+            localGridSize * mpiTopology), /* logical size of the data of all processes */
+            DomainCollector::GridType,    /* we are writing grid (not poly) data here */
+            data);                        /* the actual data buffer (pointer) */
+
+    pdc.close();
+
+    delete[] data;
+    } /* destroy ParallelDomainCollector */
+
+    MPI_Finalize();
+
+    return 0;
+}


### PR DESCRIPTION
Adds an example using the `ParallelDataCollector`.

Tries to be as close as possible to the "serial" (multiple POSIX files from MPI ranks) example of `mpi_domain_write`.