### PR TITLE
fix usage of temporary pointer

### DIFF
--- a/src/DCDataSet.cpp
+++ b/src/DCDataSet.cpp
@@ -161,11 +161,12 @@ namespace splash
     void DCDataSet::setChunking(size_t typeSize)
     throw (DCException)
     {
-        if (getPhysicalSize().getScalarSize() != 0)
+        Dimensions physicalSize(getPhysicalSize());
+        if (physicalSize.getScalarSize() != 0)
         {
             // get chunking dimensions
-            hsize_t chunk_dims[ndims];
-            DCHelper::getOptimalChunkDims(getPhysicalSize().getPointer(), ndims,
+            hsize_t chunk_dims[ndims];      
+            DCHelper::getOptimalChunkDims(physicalSize.getPointer(), ndims,
                     typeSize, chunk_dims);
 
             if (H5Pset_chunk(this->dsetProperties, ndims, chunk_dims) < 0)
@@ -219,7 +220,8 @@ namespace splash
         setChunking(colType.getSize());
         setCompression();
 
-        if (getPhysicalSize().getScalarSize() != 0)
+        Dimensions physicalSize(getPhysicalSize());
+        if (physicalSize.getScalarSize() != 0)
         {
             hsize_t *max_dims = new hsize_t[ndims];
             for (size_t i = 0; i < ndims; ++i)
@@ -227,10 +229,10 @@ namespace splash
                 if (extensible)
                     max_dims[i] = H5F_UNLIMITED;
                 else
-                    max_dims[i] = getPhysicalSize()[i];
+                    max_dims[i] = physicalSize[i];
             }
-
-            dataspace = H5Screate_simple(ndims, getPhysicalSize().getPointer(), max_dims);
+                      
+            dataspace = H5Screate_simple(ndims, physicalSize.getPointer(), max_dims);
 
             delete[] max_dims;
             max_dims = NULL;


### PR DESCRIPTION
- create helper variable to prevent that a pointer of a temporary object is used
- removed end of line white spaces (automatic done by my IDE)

**More information:**

The method `getPhysicalSize()` returned a temporary object of the type `Dimensions`. If `getPointer()` of the result is called a pointer to an already deleted object is returned and used. The result is a race condition and a memory access to a non valid address.

- [ ] do not merge, maybe this is not a bug