### PR TITLE
Catch By Reference

### DIFF
--- a/src/DomainCollector.cpp
+++ b/src/DomainCollector.cpp
@@ -183,7 +183,7 @@ namespace splash
                 dc_datatype = tmp_dataset.getDCDataType();
 
                 tmp_dataset.close();
-            } catch (DCException e)
+            } catch (const DCException& e)
             {
                 throw e;
             }
@@ -307,7 +307,7 @@ namespace splash
                 dc_datatype = tmp_dataset.getDCDataType();
 
                 tmp_dataset.close();
-            } catch (DCException e)
+            } catch (const DCException& e)
             {
                 throw e;
             }
@@ -770,7 +770,7 @@ namespace splash
         try
         {
             readSizeInternal(handles.get(0), id, name, elements);
-        } catch (DCException expected_exception)
+        } catch (const DCException&)
         {
             // nothing to do here but to make sure elements is set correctly
             elements.set(0, 1, 1);
@@ -793,7 +793,7 @@ namespace splash
         try
         {
             readAttribute(id, dataName, DOMCOL_ATTR_GLOBAL_SIZE, data, mpiPosition);
-        } catch (DCException)
+        } catch (const DCException&)
         {
             hsize_t local_size[DSP_DIM_MAX];
             readAttribute(id, dataName, DOMCOL_ATTR_SIZE, local_size, mpiPosition);
@@ -812,7 +812,7 @@ namespace splash
         try
         {
             readAttribute(id, dataName, DOMCOL_ATTR_GLOBAL_OFFSET, data, mpiPosition);
-        } catch (DCException)
+        } catch (const DCException&)
         {
             for (int i = 0; i < DSP_DIM_MAX; ++i)
                 data[i] = 0;

--- a/src/ParallelDataCollector.cpp
+++ b/src/ParallelDataCollector.cpp
@@ -330,7 +330,7 @@ namespace splash
         try
         {
             DCAttribute::readAttribute(name, group_custom.getHandle(), data);
-        } catch (DCException e)
+        } catch (const DCException& e)
         {
             log_msg(0, "Exception: %s", e.what());
             throw DCException(getExceptionString("readGlobalAttribute", "failed to open attribute", name));
@@ -370,7 +370,7 @@ namespace splash
         try
         {
             DCAttribute::writeAttribute(name, type.getDataType(), group_custom.getHandle(), ndims, dims, data);
-        } catch (DCException e)
+        } catch (const DCException& e)
         {
             log_msg(0, "Exception: %s", e.what());
             throw DCException(getExceptionString("writeGlobalAttribute", "failed to write attribute", name));
@@ -420,7 +420,7 @@ namespace splash
             try
             {
                 DCAttribute::readAttribute(attrName, obj_id, data);
-            } catch (DCException)
+            } catch (const DCException&)
             {
                 H5Oclose(obj_id);
                 throw;
@@ -491,7 +491,7 @@ namespace splash
             try
             {
                 DCAttribute::writeAttribute(attrName, type.getDataType(), obj_id, ndims, dims, data);
-            } catch (DCException)
+            } catch (const DCException&)
             {
                 H5Oclose(obj_id);
                 throw;

--- a/src/ParallelDomainCollector.cpp
+++ b/src/ParallelDomainCollector.cpp
@@ -174,7 +174,7 @@ namespace splash
                     dc_datatype = tmp_dataset.getDCDataType();
 
                     tmp_dataset.close();
-                } catch (DCException e)
+                } catch (const DCException& e)
                 {
                     H5Gclose(group_id);
                     throw e;
@@ -247,7 +247,7 @@ namespace splash
                     dc_datatype = tmp_dataset.getDCDataType();
 
                     tmp_dataset.close();
-                } catch (DCException e)
+                } catch (const DCException& e)
                 {
                     H5Gclose(group_id);
                     throw e;

--- a/src/SDCHelper.cpp
+++ b/src/SDCHelper.cpp
@@ -69,7 +69,7 @@ namespace splash
                         group_header, mpiSize->getPointer());
             }
 
-        } catch (DCException attr_exception) {
+        } catch (const DCException&) {
             H5Fclose(reference_file);
             throw DCException(getExceptionString(
                     std::string("Failed to read attributes from reference file ") +
@@ -128,7 +128,7 @@ namespace splash
             DCAttribute::writeAttribute(SDC_ATTR_FORMAT, ctStringFormat.getDataType(),
                     group_header, splashFormat.str().c_str());
 
-        } catch (DCException attr_error) {
+        } catch (const DCException& attr_error) {
             throw DCException(getExceptionString(
                 std::string("Failed to write header attribute in reference file. Error was: ") +
                 std::string(attr_error.what())));

--- a/src/SerialDataCollector.cpp
+++ b/src/SerialDataCollector.cpp
@@ -169,7 +169,7 @@ namespace splash
                 ColTypeInt32 ctInt32;
                 DCAttribute::writeAttribute(SDC_ATTR_MAX_ID, ctInt32.getDataType(),
                         group.getHandle(), &maxID);
-            } catch (DCException e)
+            } catch (const DCException& e)
             {
                 log_msg(0, "Exception: %s", e.what());
                 log_msg(1, "continuing...");
@@ -223,7 +223,7 @@ namespace splash
         try
         {
             DCAttribute::readAttribute(name, group_custom.getHandle(), data);
-        } catch (DCException e)
+        } catch (const DCException&)
         {
             throw DCException(getExceptionString("readGlobalAttribute", "failed to open attribute", name));
         }
@@ -260,7 +260,7 @@ namespace splash
         try
         {
             DCAttribute::writeAttribute(name, type.getDataType(), group_custom.getHandle(), ndims, dims, data);
-        } catch (DCException e)
+        } catch (const DCException& e)
         {
             std::cerr << e.what() << std::endl;
             throw DCException(getExceptionString("writeGlobalAttribute", "failed to write attribute", name));
@@ -313,7 +313,7 @@ namespace splash
                 try
                 {
                     DCAttribute::readAttribute(attrName, obj_id, data);
-                } catch (DCException)
+                } catch (const DCException&)
                 {
                     H5Oclose(obj_id);
                     throw;
@@ -390,7 +390,7 @@ namespace splash
             try
             {
                 DCAttribute::writeAttribute(attrName, type.getDataType(), obj_id, ndims, dims, data);
-            } catch (DCException)
+            } catch (const DCException&)
             {
                 H5Oclose(obj_id);
                 throw;
@@ -470,7 +470,7 @@ namespace splash
         try
         {
             writeDataSet(group.getHandle(), type, ndims, select, dset_name.c_str(), data);
-        } catch (DCException)
+        } catch (const DCException&)
         {
             throw;
         }
@@ -507,7 +507,7 @@ namespace splash
         {
             appendDataSet(group.getHandle(), type, count, offset,
                     stride, dset_name.c_str(), data);
-        } catch (DCException)
+        } catch (const DCException&)
         {
             throw;
         }
@@ -610,7 +610,7 @@ namespace splash
             dst_dataset.close();
             src_dataset.close();
 
-        } catch (DCException e)
+        } catch (const DCException& e)
         {
             throw e;
         }
@@ -663,7 +663,7 @@ namespace splash
             dst_dataset.close();
             src_dataset.close();
 
-        } catch (DCException e)
+        } catch (const DCException& e)
         {
             throw e;
         }
@@ -916,7 +916,7 @@ namespace splash
             ndims = dataset.getNDims();
 
             dataset.close();
-        } catch (DCException e)
+        } catch (const DCException& e)
         {
             throw e;
         }
@@ -1030,7 +1030,7 @@ namespace splash
             dataset.open(group.getHandle());
             sizeRead.set(dataset.getSize());
             dataset.close();
-        } catch (DCException e)
+        } catch (const DCException& e)
         {
             throw e;
         }

--- a/tools/splashtools.cpp
+++ b/tools/splashtools.cpp
@@ -320,7 +320,7 @@ int detectFileMPISize(Options& options, Dimensions &fileMPISizeDim)
         dc->open(options.filename.c_str(), fileCAttr);
         dc->getMPISize(fileMPISizeDim);
         dc->close();
-    } catch (DCException e)
+    } catch (const DCException& e)
     {
         std::cerr << "[0] Detecting file MPI size failed!" << std::endl <<
                 e.what() << std::endl;
@@ -446,7 +446,7 @@ int deleteFromIteration(Options& options, DataCollector *dc, const char *filenam
         dc->open(filename, fileCAttr);
         deleteFromIterationInFile(dc, options.iteration);
         dc->close();
-    } catch (DCException e)
+    } catch (const DCException& e)
     {
         std::cerr << "[" << options.mpiRank << "] " <<
                 "Deleting in file " << filename << " failed!" << std::endl <<


### PR DESCRIPTION
C++ catch parameters should be passed by const reference.

This PR was not triggered by an immediate problem but should be fixed since it usually causes problems (e.g., boost program options usually segfaults when catched wrong). Found via [flint++](https://github.com/L2Program/FlintPlusPlus) checking.

References:
  - http://en.cppreference.com/w/cpp/language/try_catch