### PR TITLE
Fix #224 `readMeta` ColType Detection

### DIFF
--- a/src/ParallelDataCollector.cpp
+++ b/src/ParallelDataCollector.cpp
@@ -998,11 +998,28 @@ namespace splash
 
         getEntriesForID(id, &(*entries.begin()), NULL);
 
+        // find entry by name
+        int32_t entry_id = -1;
+        for(size_t i = 0; i < entrySize; ++i)
+            if(std::string(name) == entries[i].name)
+            {
+                entry_id = int32_t(i);
+                break;
+            }
+
+        if(entry_id < 0)
+            throw DCException(getExceptionString("readDataSetMeta", "Entry not found by name"));
+
         Dimensions src_size(dataset.getSize() - srcOffset);
         dataset.read(dstBuffer, dstOffset, src_size, srcOffset, sizeRead, srcDims, NULL);
         dataset.close();
 
-        return entries[0].colType;
+        log_msg(3, "Entry '%s' (%d) is of type: %s",
+                entries[entry_id].name.c_str(),
+                entry_id,
+                entries[entry_id].colType->toString().c_str());
+
+        return entries[entry_id].colType;
     }
 
     void ParallelDataCollector::writeDataSet(H5Handle group,

--- a/src/SerialDataCollector.cpp
+++ b/src/SerialDataCollector.cpp
@@ -1004,11 +1004,28 @@ namespace splash
 
         getEntriesForID(id, &(*entries.begin()), NULL);
 
+        // find entry by name
+        int32_t entry_id = -1;
+        for(size_t i = 0; i < entrySize; ++i)
+            if(std::string(name) == entries[i].name)
+            {
+                entry_id = int32_t(i);
+                break;
+            }
+
+        if(entry_id < 0)
+            throw DCException(getExceptionString("readDataSetMeta", "Entry not found by name"));
+
         Dimensions src_size(dataset.getSize() - srcOffset);
         dataset.read(dstBuffer, dstOffset, src_size, srcOffset, sizeRead, srcDims, NULL);
         dataset.close();
 
-        return entries[0].colType;
+        log_msg(3, "Entry '%s' (%d) is of type: %s",
+                entries[entry_id].name.c_str(),
+                entry_id,
+                entries[entry_id].colType->toString().c_str());
+
+        return entries[entry_id].colType;
     }
 
     void SerialDataCollector::readSizeInternal(H5Handle h5File,

--- a/src/include/splash/basetypes/ColTypeBool.hpp
+++ b/src/include/splash/basetypes/ColTypeBool.hpp
@@ -69,7 +69,7 @@ public:
             {
                 char* m0 = H5Tget_member_name(datatype_id,0);
                 char* m1 = H5Tget_member_name(datatype_id,1);
-                if(strcmp("true" , m0) == 0 && strcmp("false", m1) == 0)
+                if(strcmp("TRUE" , m0) == 0 && strcmp("FALSE", m1) == 0)
                     found = true;
                 free(m1);
                 free(m0);

--- a/tests/Parallel_SimpleDataTest.cpp
+++ b/tests/Parallel_SimpleDataTest.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Felix Schmitt
+ * Copyright 2013-2016 Felix Schmitt, Axel Huebl
  *
  * This file is part of libSplash.
  *
@@ -26,6 +26,7 @@
 #include <string.h>
 #include <set>
 #include <string>
+#include <typeinfo>
 
 #include "Parallel_SimpleDataTest.h"
 
@@ -45,7 +46,7 @@ CPPUNIT_TEST_SUITE_REGISTRATION(Parallel_SimpleDataTest);
 using namespace splash;
 
 Parallel_SimpleDataTest::Parallel_SimpleDataTest() :
-ctInt(),
+ctInt32(),
 parallelDataCollector(NULL)
 {
     srand(10);
@@ -68,7 +69,7 @@ Parallel_SimpleDataTest::~Parallel_SimpleDataTest()
 }
 
 bool Parallel_SimpleDataTest::testData(const Dimensions mpiSize,
-        const Dimensions gridSize, int *data)
+        const Dimensions gridSize, int32_t *data)
 {
     for (size_t z = 0; z < mpiSize[2]; ++z)
         for (size_t y = 0; y < mpiSize[1]; ++y)
@@ -124,18 +125,18 @@ bool Parallel_SimpleDataTest::subtestWriteRead(int32_t iteration,
     fileCAttr.enableCompression = false;
     parallelDataCollector->open(HDF5_FILE, fileCAttr);
 
-    int *dataWrite = new int[bufferSize];
+    int32_t *dataWrite = new int32_t[bufferSize];
 
     for (uint32_t i = 0; i < bufferSize; i++)
         dataWrite[i] = currentMpiRank + 1;
 
-    parallelDataCollector->write(iteration, ctInt, dimensions, gridSize,
+    parallelDataCollector->write(iteration, ctInt32, dimensions, gridSize,
             "deep/folder/data", dataWrite);
     datasetNames.insert("deep/folder/data");
-    parallelDataCollector->write(iteration, ctInt, dimensions, gridSize,
+    parallelDataCollector->write(iteration, ctInt32, dimensions, gridSize,
             "deep/folder/data2", dataWrite);
     datasetNames.insert("deep/folder/data2");
-    parallelDataCollector->write(iteration, ctInt, dimensions, gridSize,
+    parallelDataCollector->write(iteration, ctInt32, dimensions, gridSize,
             "another_dataset", dataWrite);
     datasetNames.insert("another_dataset");
     parallelDataCollector->close();
@@ -153,8 +154,8 @@ bool Parallel_SimpleDataTest::subtestWriteRead(int32_t iteration,
 
     Dimensions size_read;
     Dimensions full_grid_size = gridSize * mpiSize;
-    int *data_read = new int[full_grid_size.getScalarSize()];
-    memset(data_read, 0, sizeof (int) * full_grid_size.getScalarSize());
+    int32_t *data_read = new int32_t[full_grid_size.getScalarSize()];
+    memset(data_read, 0, sizeof (int32_t) * full_grid_size.getScalarSize());
 
     // test using SerialDataCollector
     if (currentMpiRank == 0)
@@ -173,7 +174,7 @@ bool Parallel_SimpleDataTest::subtestWriteRead(int32_t iteration,
     MPI_CHECK(MPI_Barrier(mpiComm));
 
     // test using full read per process
-    memset(data_read, 0, sizeof (int) * full_grid_size.getScalarSize());
+    memset(data_read, 0, sizeof (int32_t) * full_grid_size.getScalarSize());
     ParallelDataCollector *readCollector = new ParallelDataCollector(mpiComm,
             MPI_INFO_NULL, mpiSize, 1);
 
@@ -202,6 +203,7 @@ bool Parallel_SimpleDataTest::subtestWriteRead(int32_t iteration,
         {
             /* test that listed datasets match expected dataset names*/
             CPPUNIT_ASSERT(datasetNames.find(entries[i].name) != datasetNames.end());
+            CPPUNIT_ASSERT(typeid(*entries[i].colType) == typeid(ColTypeInt32));
         }
 
         delete[] entries;
@@ -209,6 +211,18 @@ bool Parallel_SimpleDataTest::subtestWriteRead(int32_t iteration,
     }
 
     readCollector->read(iteration, "deep/folder/data", size_read, data_read);
+
+    Dimensions dstBuffer(size_read);
+    Dimensions dstOffset(0, 0, 0);
+    Dimensions sizeRead(0, 0, 0);
+    CollectionType* colType = readCollector->readMeta(iteration,
+        "deep/folder/data", dstBuffer, dstOffset, sizeRead);
+
+    CPPUNIT_ASSERT(typeid(*colType) == typeid(ColTypeInt32));
+    CPPUNIT_ASSERT(typeid(*colType) != typeid(ColTypeUInt32));
+    CPPUNIT_ASSERT(typeid(*colType) != typeid(ColTypeUInt64));
+    CPPUNIT_ASSERT(typeid(*colType) != typeid(ColTypeDouble));
+
     readCollector->close();
 
     CPPUNIT_ASSERT(size_read == full_grid_size);
@@ -218,8 +232,8 @@ bool Parallel_SimpleDataTest::subtestWriteRead(int32_t iteration,
     MPI_CHECK(MPI_Barrier(mpiComm));
 
     // test using parallel read
-    data_read = new int[gridSize.getScalarSize()];
-    memset(data_read, 0, sizeof (int) * gridSize.getScalarSize());
+    data_read = new int32_t[gridSize.getScalarSize()];
+    memset(data_read, 0, sizeof (int32_t) * gridSize.getScalarSize());
 
     const Dimensions globalOffset = gridSize * mpiPos;
     readCollector->open(HDF5_FILE, fileCAttr);
@@ -379,7 +393,7 @@ bool Parallel_SimpleDataTest::subtestFill(int32_t iteration,
     fileCAttr.enableCompression = false;
     parallelDataCollector->open(HDF5_FILE, fileCAttr);
 
-    int dataWrite = currentMpiRank + 1;
+    int32_t dataWrite = currentMpiRank + 1;
     uint32_t num_elements = (currentMpiRank + 1) * elements;
     Dimensions grid_size(num_elements, 1, 1);
 
@@ -389,10 +403,10 @@ bool Parallel_SimpleDataTest::subtestFill(int32_t iteration,
 
     Dimensions globalOffset, globalSize;
     parallelDataCollector->reserve(iteration, grid_size,
-            &globalSize, &globalOffset, 1, ctInt, "reserved/reserved_data");
+            &globalSize, &globalOffset, 1, ctInt32, "reserved/reserved_data");
 
-    int attrVal = currentMpiRank;
-    parallelDataCollector->writeAttribute(iteration, ctInt, "reserved/reserved_data",
+    int32_t attrVal = currentMpiRank;
+    parallelDataCollector->writeAttribute(iteration, ctInt32, "reserved/reserved_data",
             "reserved_attr", &attrVal);
 
     uint32_t elements_written = 0;
@@ -437,8 +451,8 @@ bool Parallel_SimpleDataTest::subtestFill(int32_t iteration,
     // test using SerialDataCollector
     if (currentMpiRank == 0)
     {
-        int *data_read = new int[full_grid_size.getScalarSize()];
-        memset(data_read, 0, sizeof (int) * full_grid_size.getScalarSize());
+        int32_t *data_read = new int32_t[full_grid_size.getScalarSize()];
+        memset(data_read, 0, sizeof (int32_t) * full_grid_size.getScalarSize());
 
         DataCollector *dataCollector = new SerialDataCollector(1);
         dataCollector->open(filename_stream.str().c_str(), fileCAttr);

--- a/tests/SimpleDataTest.cpp
+++ b/tests/SimpleDataTest.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2014 Felix Schmitt
+ * Copyright 2013-2016 Felix Schmitt, Axel Huebl
  *
  * This file is part of libSplash.
  *
@@ -29,6 +29,7 @@
 #include <set>
 #include <string>
 #include <cstring>
+#include <typeinfo>
 
 #include "SimpleDataTest.h"
 
@@ -178,7 +179,20 @@ bool SimpleDataTest::subtestWriteRead(Dimensions gridSize, Dimensions borderSize
     }
 
     Dimensions resultSize;
+
     dataCollector->read(10, "deep/folders/data", resultSize, dataRead);
+
+    Dimensions dstBuffer(resultSize);
+    Dimensions dstOffset(0, 0, 0);
+    Dimensions sizeRead(0, 0, 0);
+    CollectionType* colType = dataCollector->readMeta(10, "deep/folders/data_bool", dstBuffer, dstOffset, sizeRead);
+
+    std::cout << colType->toString() << std::endl;
+
+    CPPUNIT_ASSERT(typeid(*colType) == typeid(ColTypeBool));
+    CPPUNIT_ASSERT(typeid(*colType) != typeid(ColTypeUInt64));
+    CPPUNIT_ASSERT(typeid(*colType) != typeid(ColTypeInt64));
+    CPPUNIT_ASSERT(typeid(*colType) != typeid(ColTypeDouble));
 
     for (uint32_t i = 0; i < 3; i++)
         CPPUNIT_ASSERT(resultSize[i] == gridSize[i]);

--- a/tests/include/Parallel_SimpleDataTest.h
+++ b/tests/include/Parallel_SimpleDataTest.h
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Felix Schmitt
+ * Copyright 2013-2016 Felix Schmitt, Axel Huebl
  *
  * This file is part of libSplash.
  *
@@ -53,7 +53,7 @@ private:
     void testFill();
 
     bool testData(const Dimensions mpiSize, const Dimensions gridSize,
-            int *data);
+            int32_t *data);
 
     /**
      * sub function for testWriteRead to allow several data sizes to be tested.
@@ -68,7 +68,7 @@ private:
     bool subtestFill(int32_t iteration, int currentMpiRank, const Dimensions mpiSize,
             const Dimensions mpiPos, uint32_t elements, MPI_Comm mpiComm);
 
-    ColTypeInt ctInt;
+    ColTypeInt32 ctInt32;
     IParallelDataCollector *parallelDataCollector;
 
     int totalMpiSize;


### PR DESCRIPTION
Fixes #224 by implementing the `readMeta` members in `[Serial|Parallel]DataCollector` correctly in case more then one `entry` (data set) is available per iteration.

Implements:
- read meta data tests that check the `CollectionType` (serial, parallel)

Fixes
- `ColTypeBool` detection (was detected as `Unknown` due to a representation change in the last release)
- `readMeta` return type (returned first found `entry` before)