### PR TITLE
ChangeLog for Release 1.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,30 @@
 Change Log for libSplash
 ================================================================
 
+Release 1.3.1
+-------------
+**Date:** 2016-04-12
+
+This release contains bug fixes and serveral internal code
+clean-ups.
+
+**Bug Fixes**
+
+ - `readMeta` now returns the correct `CollectionType` if more then
+   one entry was used per iteration #224
+ - exception parameters are now catched consequently by const
+   reference #213
+
+
+**Misc**
+
+ - remove tabs and EOL white spaces #216 #217 #218
+ - remove `_` prefixes from a few include guards #214
+ - add example for the `ParallelDataCollector` class #14
+ - remove beta notice for parallel HDF5 support #209
+ - update travis-ci script #212
+
+
 Release 1.3.0
 -------------
 **Date:** 2015-11-12

--- a/src/include/splash/version.hpp
+++ b/src/include/splash/version.hpp
@@ -26,7 +26,7 @@
 /** the splash version reflects the changes in API */
 #define SPLASH_VERSION_MAJOR 1
 #define SPLASH_VERSION_MINOR 3
-#define SPLASH_VERSION_PATCH 0
+#define SPLASH_VERSION_PATCH 1
 
 /** we can always handle files from the same major release
  *  changes in the minor number have to be backwards compatible


### PR DESCRIPTION
Change log for the `1.3.1` bug fix release.

Increases the version number to `1.3.1`, file format unchanged.