### PR TITLE
Close #219 SDC GlobalAttibute Path to "/"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,19 @@
 Change Log for libSplash
 ================================================================
 
+Release 1.4.0
+-------------
+**Date:** 2016-04-12
+
+The `SerialDataCollector` now also writes global attributes
+to `/`, allowing serial files to fulfill the openPMD standard.
+
+**Interface Changes**
+
+ - `SerialDataCollector::writeGlobalAttribute` now writes to `/`
+   instead of `/custom` (follow-up to #182) #229
+
+
 Release 1.3.1
 -------------
 **Date:** 2016-04-12

--- a/src/DCGroup.cpp
+++ b/src/DCGroup.cpp
@@ -103,8 +103,10 @@ namespace splash
     throw (DCException)
     {
         H5Handle newHandle;
+        const bool is_basepath(path == std::string("/"));
 
-        if (checkExistence && !H5Lexists(base, path.c_str(), H5P_DEFAULT))
+        if (checkExistence && !H5Lexists(base, path.c_str(), H5P_DEFAULT) &&
+            !is_basepath)
             throw DCException(getExceptionString("Failed to open group", path));
 
         newHandle = H5Gopen(base, path.c_str(), H5P_DEFAULT);

--- a/src/include/splash/sdc_defines.hpp
+++ b/src/include/splash/sdc_defines.hpp
@@ -28,7 +28,7 @@ namespace splash
 #define SDC_GROUP_HEADER "/header"
 #define SDC_GROUP_DATA "/data"
 #define SDC_GROUP_ITERATION "iteration"
-#define SDC_GROUP_CUSTOM "/custom"
+#define SDC_GROUP_CUSTOM "/"
 #define SDC_ATTR_DIM_LOCAL "dim_local"
 #define SDC_ATTR_DIM_GLOBAL "dim_global"
 #define SDC_ATTR_MAX_ID "max_id"

--- a/src/include/splash/version.hpp
+++ b/src/include/splash/version.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015 Felix Schmitt, Axel Huebl
+ * Copyright 2013-2016 Felix Schmitt, Axel Huebl
  *
  * This file is part of libSplash.
  *
@@ -25,14 +25,14 @@
 
 /** the splash version reflects the changes in API */
 #define SPLASH_VERSION_MAJOR 1
-#define SPLASH_VERSION_MINOR 3
-#define SPLASH_VERSION_PATCH 1
+#define SPLASH_VERSION_MINOR 4
+#define SPLASH_VERSION_PATCH 0
 
 /** we can always handle files from the same major release
  *  changes in the minor number have to be backwards compatible
  */
-#define SPLASH_FILE_FORMAT_MAJOR 3
-#define SPLASH_FILE_FORMAT_MINOR 3
+#define SPLASH_FILE_FORMAT_MAJOR 4
+#define SPLASH_FILE_FORMAT_MINOR 0
 
 /** The version of HDF5 that was used to compile splash */
 #define SPLASH_HDF5_VERSION "${HDF5_VERSION}"

--- a/tests/readBoolChar.py
+++ b/tests/readBoolChar.py
@@ -52,7 +52,7 @@ f.close()
 f = h5py.File("h5/attributes_array_0_0_0.h5", "r")
 
 # array attributes
-dg = f["custom"].attrs["testposition"]
+dg = f.attrs["testposition"]
 print(dg, type(dg), dg.dtype)
 
 ref_dg = np.array([17, 12, -99], dtype="int")


### PR DESCRIPTION
Close #219 by letting the `SerialDataCollector` write to `/` by default, too.
Follow-up to the change in `1.3.0` for the PDC (see #173).

Needed by several users to fulfill the `openPMD` standard with **serial** files where they actually want to write to pathes starting from `/`.

This PR already contains a change log since this will be the only change from the todays `1.3.1` release to go to `1.4.0`.  Reading old files needs manual tuning for global attributes: API increased to `1.4.0` and file format bumped to `4.0` since the changes in SDC are not backwards compatible without chaning the interpretation of the `write/readGlobalAttribute` API calls.

CC-ing @PrometheusPi (I will update PIConGPU requirements in the next days)