### PR TITLE
Make filename creation consistent

### DIFF
--- a/src/HandleMgr.cpp
+++ b/src/HandleMgr.cpp
@@ -69,6 +69,16 @@ namespace splash
         return full_msg.str();
     }
 
+    void HandleMgr::setFileNameScheme(FileNameScheme fileNameScheme) throw (DCException)
+    {
+        if (this->fileNameScheme == fileNameScheme)
+            return;
+        if (!filename.empty())
+            throw DCException(getExceptionString("setFileNameScheme",
+                                    "Tried to change scheme while file(s) were still open", ""));
+        this->fileNameScheme = fileNameScheme;
+    }
+
     void HandleMgr::open(Dimensions mpiSize, const std::string baseFilename,
             hid_t fileAccProperties, unsigned flags)
     throw (DCException)
@@ -101,15 +111,11 @@ namespace splash
             hid_t fileAccProperties, unsigned flags)
     throw (DCException)
     {
+        setFileNameScheme(FNS_FULLNAME);
         this->mpiSize.set(1, 1, 1);
         this->filename = fullFilename;
         this->fileAccProperties = fileAccProperties;
         this->fileFlags = flags;
-        if (fileNameScheme != FNS_FULLNAME)
-        {
-            throw DCException(getExceptionString("open", "Must use FNS_FULLNAME when passing full filename",
-                                        fullFilename.c_str()));
-        }
     }
 
     uint32_t HandleMgr::indexFromPos(Dimensions& mpiPos)
@@ -173,7 +179,7 @@ namespace splash
 
             // Append prefix and extension if we don't have a full filename (extension)
             std::string fullFilename;
-            if (fileNameScheme != FNS_FULLNAME && filename.find(".h5") == filename.length() - 3)
+            if (fileNameScheme != FNS_FULLNAME && filename.find(".h5") != filename.length() - 3)
             {
                 std::stringstream filenameStream;
                 filenameStream << filename;

--- a/src/ParallelDataCollector.cpp
+++ b/src/ParallelDataCollector.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015 Felix Schmitt, Axel Huebl
+ * Copyright 2013-2016 Felix Schmitt, Axel Huebl, Alexander Grund
  *
  * This file is part of libSplash.
  *
@@ -65,14 +65,6 @@ namespace splash
         H5Pset_cache(fileAccProperties, metaCacheElements, rawCacheElements, rawCacheSize, policy);
 
         log_msg(3, "Raw Data Cache (File) = %llu KiB", (long long unsigned) (rawCacheSize / 1024));
-    }
-
-    std::string ParallelDataCollector::getFullFilename(uint32_t id, std::string baseFilename)
-    {
-        std::stringstream serial_filename;
-        serial_filename << baseFilename << "_" << id << ".h5";
-
-        return serial_filename.str();
     }
 
     std::string ParallelDataCollector::getExceptionString(std::string func, std::string msg,

--- a/src/ParallelDataCollector.cpp
+++ b/src/ParallelDataCollector.cpp
@@ -193,15 +193,16 @@ namespace splash
 
     ParallelDataCollector::~ParallelDataCollector()
     {
+        finalize();
         H5Pclose(fileAccProperties);
     }
 
     void ParallelDataCollector::finalize()
     {
-        log_msg(1, "finalizing data collector");
-
+        close();
         if (options.mpiComm != MPI_COMM_NULL)
         {
+            log_msg(1, "finalizing data collector");
             MPI_Comm_free(&options.mpiComm);
             options.mpiComm = MPI_COMM_NULL;
         }
@@ -237,6 +238,9 @@ namespace splash
 
     void ParallelDataCollector::close()
     {
+        if (fileStatus == FST_CLOSED)
+            return;
+
         log_msg(1, "closing parallel data collector");
 
         // close opened hdf5 file handles

--- a/src/ParallelDataCollector.cpp
+++ b/src/ParallelDataCollector.cpp
@@ -193,13 +193,13 @@ namespace splash
 
     ParallelDataCollector::~ParallelDataCollector()
     {
-        finalize();
+        close();
         H5Pclose(fileAccProperties);
+        finalize();
     }
 
     void ParallelDataCollector::finalize()
     {
-        close();
         if (options.mpiComm != MPI_COMM_NULL)
         {
             log_msg(1, "finalizing data collector");

--- a/src/SerialDataCollector.cpp
+++ b/src/SerialDataCollector.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015 Felix Schmitt, Axel Huebl
+ * Copyright 2013-2016 Felix Schmitt, Axel Huebl, Alexander Grund
  *
  * This file is part of libSplash.
  *
@@ -72,6 +72,9 @@ namespace splash
 
     std::string SerialDataCollector::getFullFilename(const Dimensions mpiPos, std::string baseFilename) const
     {
+        if (baseFilename.find(".h5") != std::string::npos)
+            return baseFilename;
+
         std::stringstream serial_filename;
         serial_filename << baseFilename << "_" << mpiPos[0] << "_" << mpiPos[1] <<
                 "_" << mpiPos[2] << ".h5";
@@ -746,7 +749,6 @@ namespace splash
     {
         this->fileStatus = FST_CREATING;
 
-        // appends the mpiPosition to the filename (e.g. myfile_0_1_0.h5)
         std::string full_filename = getFullFilename(attr.mpiPosition, filename);
         DCHelper::testFilename(full_filename);
 
@@ -779,10 +781,7 @@ namespace splash
     {
         fileStatus = FST_WRITING;
 
-        std::string full_filename = filename;
-        if (full_filename.find(".h5") == std::string::npos)
-            full_filename = getFullFilename(attr.mpiPosition, filename);
-
+        std::string full_filename = getFullFilename(attr.mpiPosition, filename);
         DCHelper::testFilename(full_filename);
 
         this->enableCompression = attr.enableCompression;
@@ -806,7 +805,6 @@ namespace splash
 
         // open reference file to get mpi information
         std::string full_filename = getFullFilename(Dimensions(0, 0, 0), filename);
-
         DCHelper::testFilename(full_filename);
 
         if (!fileExists(full_filename))
@@ -829,10 +827,7 @@ namespace splash
     {
         this->fileStatus = FST_READING;
 
-        std::string full_filename = filename;
-        if (full_filename.find(".h5") == std::string::npos)
-            full_filename = getFullFilename(attr.mpiPosition, filename);
-
+        std::string full_filename = getFullFilename(attr.mpiPosition, filename);
         DCHelper::testFilename(full_filename);
 
         if (!fileExists(full_filename))

--- a/src/SerialDataCollector.cpp
+++ b/src/SerialDataCollector.cpp
@@ -35,7 +35,6 @@
 #include "splash/core/DCAttribute.hpp"
 #include "splash/core/DCDataSet.hpp"
 #include "splash/core/DCGroup.hpp"
-#include "splash/core/DCHelper.hpp"
 #include "splash/core/SDCHelper.hpp"
 #include "splash/core/logging.hpp"
 #include "splash/basetypes/basetypes.hpp"
@@ -100,7 +99,7 @@ namespace splash
      *******************************************************************************/
 
     SerialDataCollector::SerialDataCollector(uint32_t maxFileHandles) :
-    handles(maxFileHandles, HandleMgr::FNS_MPI),
+    handles(maxFileHandles, HandleMgr::FNS_FULLNAME),
     fileStatus(FST_CLOSED),
     maxID(-1),
     mpiTopology(1, 1, 1)
@@ -116,7 +115,7 @@ namespace splash
                 "failed to initialize/open HDF5 library"));
 
 #ifndef SPLASH_VERBOSE_HDF5
-        // surpress automatic output of HDF5 exception messages
+        // Suppress automatic output of HDF5 exception messages
         if (H5Eset_auto2(H5E_DEFAULT, NULL, NULL) < 0)
             throw DCException(getExceptionString("SerialDataCollector",
                 "failed to disable error printing"));
@@ -750,7 +749,6 @@ namespace splash
         this->fileStatus = FST_CREATING;
 
         std::string full_filename = getFullFilename(attr.mpiPosition, filename);
-        DCHelper::testFilename(full_filename);
 
         this->enableCompression = attr.enableCompression;
 
@@ -782,7 +780,6 @@ namespace splash
         fileStatus = FST_WRITING;
 
         std::string full_filename = getFullFilename(attr.mpiPosition, filename);
-        DCHelper::testFilename(full_filename);
 
         this->enableCompression = attr.enableCompression;
 
@@ -805,7 +802,6 @@ namespace splash
 
         // open reference file to get mpi information
         std::string full_filename = getFullFilename(Dimensions(0, 0, 0), filename);
-        DCHelper::testFilename(full_filename);
 
         if (!fileExists(full_filename))
         {
@@ -828,7 +824,6 @@ namespace splash
         this->fileStatus = FST_READING;
 
         std::string full_filename = getFullFilename(attr.mpiPosition, filename);
-        DCHelper::testFilename(full_filename);
 
         if (!fileExists(full_filename))
         {

--- a/src/SerialDataCollector.cpp
+++ b/src/SerialDataCollector.cpp
@@ -128,6 +128,7 @@ namespace splash
 
     SerialDataCollector::~SerialDataCollector()
     {
+        close();
     }
 
     void SerialDataCollector::open(const char* filename, FileCreationAttr &attr)
@@ -160,6 +161,9 @@ namespace splash
 
     void SerialDataCollector::close()
     {
+        if (fileStatus == FST_CLOSED)
+            return;
+
         log_msg(1, "closing serial data collector");
 
         if (fileStatus == FST_CREATING || fileStatus == FST_WRITING)

--- a/src/SerialDataCollector.cpp
+++ b/src/SerialDataCollector.cpp
@@ -816,6 +816,7 @@ namespace splash
         // no compression for in-memory datasets
         this->enableCompression = false;
 
+        handles.setFileNameScheme(HandleMgr::FNS_MPI);
         handles.open(mpiTopology, filename, fileAccProperties, H5F_ACC_RDONLY);
     }
 

--- a/src/SerialDataCollector.cpp
+++ b/src/SerialDataCollector.cpp
@@ -71,7 +71,8 @@ namespace splash
 
     std::string SerialDataCollector::getFullFilename(const Dimensions mpiPos, std::string baseFilename) const
     {
-        if (baseFilename.find(".h5") != std::string::npos)
+        // Check for existing extension
+        if (baseFilename.find(".h5") == baseFilename.length() - 3)
             return baseFilename;
 
         std::stringstream serial_filename;

--- a/src/include/splash/ParallelDataCollector.hpp
+++ b/src/include/splash/ParallelDataCollector.hpp
@@ -55,16 +55,6 @@ namespace splash
         void setFileAccessParams(hid_t& fileAccProperties);
 
         /**
-         * Constructs a filename from a base filename and the current id
-         * such as baseFilename+id+.h5
-         *
-         * @param id Iteration ID.
-         * @param baseFilename Base filename for the new file.
-         * @return newly Constructed filename including file extension.
-         */
-        static std::string getFullFilename(uint32_t id, std::string baseFilename);
-
-        /**
          * Internal function for formatting exception messages.
          *
          * @param func name of the throwing function

--- a/src/include/splash/SerialDataCollector.hpp
+++ b/src/include/splash/SerialDataCollector.hpp
@@ -61,10 +61,11 @@ namespace splash
         /**
          * Constructs a filename from a base filename and the process' mpi position
          * such as baseFilename+mpiPos+.h5
+         * Does nothing if the filename already contains a ".h5"
          *
          * @param mpiPos MPI position of the process
          * @param baseFilename base filename for the new file
-         * @return newly constructed filename iucluding file exitension
+         * @return newly constructed filename including file extension
          */
         std::string getFullFilename(const Dimensions mpiPos, std::string baseFilename) const;
 

--- a/src/include/splash/SerialDataCollector.hpp
+++ b/src/include/splash/SerialDataCollector.hpp
@@ -62,13 +62,15 @@ namespace splash
          * Constructs a filename from a base filename and the process' mpi position
          * such as myfile_0_1_0.h5
          * Does nothing if the filename already ends with ".h5" (only allowed
-         * for Prod(mpiSize)==1).
+         * for Prod(mpiSize)==1 or reading).
          *
          * @param mpiPos MPI position of the process
          * @param baseFilename base filename for the new file
+         * @param isFullNameAllowed If false, an exception is raised when a full name is passed
          * @return newly constructed filename including file extension
          */
-        std::string getFullFilename(const Dimensions mpiPos, std::string baseFilename) const;
+        std::string getFullFilename(const Dimensions mpiPos, std::string baseFilename,
+                bool isFullNameAllowed) const throw (DCException);
 
         /**
          * Internal function for formatting exception messages.

--- a/src/include/splash/SerialDataCollector.hpp
+++ b/src/include/splash/SerialDataCollector.hpp
@@ -60,8 +60,9 @@ namespace splash
 
         /**
          * Constructs a filename from a base filename and the process' mpi position
-         * such as baseFilename+mpiPos+.h5
-         * Does nothing if the filename already contains a ".h5"
+         * such as myfile_0_1_0.h5
+         * Does nothing if the filename already ends with ".h5" (only allowed
+         * for Prod(mpiSize)==1).
          *
          * @param mpiPos MPI position of the process
          * @param baseFilename base filename for the new file

--- a/src/include/splash/core/DCHelper.hpp
+++ b/src/include/splash/core/DCHelper.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013, 2015 Felix Schmitt, Axel Huebl
+ * Copyright 2013-2016 Felix Schmitt, Axel Huebl, Alexander Grund
  *
  * This file is part of libSplash.
  *
@@ -192,6 +192,13 @@ namespace splash
             if (filename.rfind(".h5.h5") == filename.length() - 6)
             {
                 std::cerr << std::endl << "\tWarning: DCHelper: Do you really want to access "
+                        << filename.c_str() << "?" << std::endl;
+                return false;
+            }
+
+            if (filename.find(".h5") != filename.length() - 3)
+            {
+                std::cerr << std::endl << "\tWarning: DCHelper: Duplicate or missing extension. Do you really want to access "
                         << filename.c_str() << "?" << std::endl;
                 return false;
             }

--- a/src/include/splash/core/DCHelper.hpp
+++ b/src/include/splash/core/DCHelper.hpp
@@ -198,7 +198,9 @@ namespace splash
 
             if (filename.find(".h5") != filename.length() - 3)
             {
-                std::cerr << std::endl << "\tWarning: DCHelper: Duplicate or missing extension. Do you really want to access "
+                std::cerr << std::endl << "\tWarning: DCHelper: "
+                        << "Duplicate or missing file name extension. "
+                        << "Do you really want to access "
                         << filename.c_str() << "?" << std::endl;
                 return false;
             }

--- a/src/include/splash/core/HandleMgr.hpp
+++ b/src/include/splash/core/HandleMgr.hpp
@@ -95,6 +95,13 @@ namespace splash
         virtual ~HandleMgr();
 
         /**
+         * Changes the file naming scheme used for newly opened files
+         * Can only be changed when no file is currently open
+         * @param fileNameScheme new file name scheme
+         */
+        void setFileNameScheme(FileNameScheme fileNameScheme) throw (DCException);
+
+        /**
          * Opens the handle manager for multiple files/handles
          * @param mpiSize MPI size
          * @param baseFilename base filename part (w/o MPI/ext)
@@ -106,6 +113,7 @@ namespace splash
 
         /**
          * Opens the handle manager for a single file/handle
+         * Changes the fileNameScheme to FNS_FULLNAME if necessary
          * @param fullFilename full filename (w/ MPI/ext)
          * @param fileAccProperties from SerialDataCollector
          * @param flags from SerialDataCollector

--- a/src/include/splash/core/HandleMgr.hpp
+++ b/src/include/splash/core/HandleMgr.hpp
@@ -111,7 +111,7 @@ namespace splash
          * @param flags from SerialDataCollector
          */
         void open(const std::string fullFilename,
-                hid_t fileAccProperties, unsigned flags);
+                hid_t fileAccProperties, unsigned flags) throw (DCException);
 
         /**
          * Closes the handle manager, closes all open file handles.
@@ -155,7 +155,6 @@ namespace splash
 
     private:
         uint32_t maxHandles;
-        uint32_t numHandles;
 
         Dimensions mpiSize;
         std::string filename;
@@ -163,7 +162,6 @@ namespace splash
 
         hid_t fileAccProperties;
         unsigned fileFlags;
-        bool singleFile;
 
         HandleMap handles;
         IndexCtrStr leastAccIndex;

--- a/src/include/splash/core/HandleMgr.hpp
+++ b/src/include/splash/core/HandleMgr.hpp
@@ -70,10 +70,11 @@ namespace splash
          * File naming schemes
          * FNS_MPI: use MPI position, e.g. file_0_2_1.h5
          * FNS_ITERATIONS: use current iteration, e.g. file_132.h5
+         * FNS_FULLNAME: use full name as passed to file functions (already contains .h5)
          */
         enum FileNameScheme
         {
-            FNS_MPI = 0, FNS_ITERATIONS
+            FNS_MPI = 0, FNS_ITERATIONS, FNS_FULLNAME
         };
 
         // callback function types

--- a/src/include/splash/core/HandleMgr.hpp
+++ b/src/include/splash/core/HandleMgr.hpp
@@ -102,7 +102,7 @@ namespace splash
          * @param flags from SerialDataCollector
          */
         void open(Dimensions mpiSize, const std::string baseFilename,
-                hid_t fileAccProperties, unsigned flags);
+                hid_t fileAccProperties, unsigned flags) throw (DCException);
 
         /**
          * Opens the handle manager for a single file/handle

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -61,7 +61,7 @@ INCLUDE_DIRECTORIES(include ../src/include $ENV{MPI_INC} )
 #-------------------------------------------------------------------------------
 
 FILE(GLOB SRCFILESOTHER "dependencies/*.cpp")
-SET(TESTS Append Attributes FileAccess References Remove SimpleData Striding)
+SET(TESTS Append Attributes FileAccess Filename References Remove SimpleData Striding)
 
 IF(WITH_MPI)
     SET(TESTS ${TESTS} Benchmark Domains)
@@ -75,7 +75,7 @@ IF(PARALLEL)
         INCLUDE_DIRECTORIES(${MPI_C_INCLUDE_PATH} ${MPI_CXX_INCLUDE_PATH})
     ENDIF(NOT WITH_MPI)
 
-    SET(TESTS ${TESTS} Parallel_Attributes Parallel_Domains Parallel_ListFiles Parallel_References Parallel_Remove Parallel_SimpleData Parallel_ZeroAccess)
+    SET(TESTS ${TESTS} Parallel_Attributes Parallel_Filename Parallel_Domains Parallel_ListFiles Parallel_References Parallel_Remove Parallel_SimpleData Parallel_ZeroAccess)
 ELSE(PARALLEL)
     SET(TESTS ${TESTS})
 ENDIF(PARALLEL)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -67,7 +67,7 @@ IF(WITH_MPI)
     SET(TESTS ${TESTS} Benchmark Domains)
 ENDIF(WITH_MPI)
 
-OPTION(PARALLEL "enable tests for parallel libSplash" @HDF5_IS_PARALLEL@)
+OPTION(PARALLEL "enable tests for parallel libSplash" ${HDF5_IS_PARALLEL})
 IF(PARALLEL)
     IF(NOT WITH_MPI)
         # MPI is required package
@@ -75,7 +75,7 @@ IF(PARALLEL)
         INCLUDE_DIRECTORIES(${MPI_C_INCLUDE_PATH} ${MPI_CXX_INCLUDE_PATH})
     ENDIF(NOT WITH_MPI)
 
-    SET(TESTS ${TESTS} Parallel_Attributes Parallel_Filename Parallel_Domains Parallel_ListFiles Parallel_References Parallel_Remove Parallel_SimpleData Parallel_ZeroAccess)
+    SET(TESTS ${TESTS} Parallel_Attributes Parallel_Filename Parallel_Domains Parallel_ListFiles Parallel_References Parallel_Remove Parallel_SerialDC Parallel_SimpleData Parallel_ZeroAccess)
 ELSE(PARALLEL)
     SET(TESTS ${TESTS})
 ENDIF(PARALLEL)

--- a/tests/FilenameTest.cpp
+++ b/tests/FilenameTest.cpp
@@ -65,7 +65,7 @@ CPPUNIT_TEST_SUITE_REGISTRATION(FilenameTest);
 
 #define HDF5_FILE "h5/testFilename"
 #define HDF5_BASE_FILE HDF5_FILE "_0_0_0.h5"
-#define HDF5_FULL_FILE HDF5_FILE ".h5"
+#define HDF5_FULL_FILE HDF5_FILE "Full.h5"
 
 FilenameTest::FilenameTest()
 {
@@ -167,7 +167,4 @@ void FilenameTest::runTest(const char* filename, const char* fullFilename)
     CPPUNIT_ASSERT(data_size.getScalarSize() == 1);
     CPPUNIT_ASSERT(data == data3);
     dataCollector->close();
-
-    // Cleanup
-    unlink(fullFilename);
 }

--- a/tests/FilenameTest.cpp
+++ b/tests/FilenameTest.cpp
@@ -1,0 +1,173 @@
+/**
+ * Copyright 2016 Alexander Grund
+ *
+ * This file is part of libSplash.
+ *
+ * libSplash is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * libSplash is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libSplash.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+ 
+ #include <cppunit/extensions/HelperMacros.h>
+
+#include "splash/splash.h"
+#include <unistd.h>
+#include <sys/stat.h>
+
+using namespace splash;
+
+class FilenameTest : public CPPUNIT_NS::TestFixture
+{
+    CPPUNIT_TEST_SUITE(FilenameTest);
+
+    CPPUNIT_TEST(testBaseName);
+    CPPUNIT_TEST(testFullName);
+
+    CPPUNIT_TEST_SUITE_END();
+
+public:
+
+    FilenameTest();
+    virtual ~FilenameTest();
+
+private:
+    /**
+     * Tests that file naming is correct when passing only base name
+     */
+    void testBaseName();
+
+    /**
+     * Tests that file naming is correct when passing full name
+     */
+    void testFullName();
+
+    void runTest(const char* filename, const char* fullFilename);
+
+    bool fileExists(const std::string& filename);
+
+    DataCollector *dataCollector;
+    ColTypeInt ctInt;
+};
+
+CPPUNIT_TEST_SUITE_REGISTRATION(FilenameTest);
+
+#define HDF5_FILE "h5/testFilename"
+#define HDF5_BASE_FILE HDF5_FILE "_0_0_0.h5"
+#define HDF5_FULL_FILE HDF5_FILE ".h5"
+
+FilenameTest::FilenameTest()
+{
+    dataCollector = new SerialDataCollector(10);
+    srand(time(NULL));
+    // Remove old files
+    unlink(HDF5_BASE_FILE);
+    unlink(HDF5_FULL_FILE);
+}
+
+FilenameTest::~FilenameTest()
+{
+    delete dataCollector;
+}
+
+bool FilenameTest::fileExists(const std::string& filename)
+{
+    struct stat fileInfo;
+    return (stat(filename.c_str(), &fileInfo) == 0);
+}
+
+void FilenameTest::testBaseName()
+{
+    // MPI rank should be appended
+    runTest(HDF5_FILE, HDF5_BASE_FILE);
+}
+
+void FilenameTest::testFullName()
+{
+    // Filename should be used unchanged
+    runTest(HDF5_FULL_FILE, HDF5_FULL_FILE);
+}
+
+void FilenameTest::runTest(const char* filename, const char* fullFilename)
+{
+    CPPUNIT_ASSERT(!fileExists(fullFilename));
+
+    DataCollector::FileCreationAttr attr;
+    DataCollector::initFileCreationAttr(attr);
+    attr.fileAccType = DataCollector::FAT_WRITE;
+
+    // write first dataset to file (create file)
+    dataCollector->open(filename, attr);
+    int data1 = rand();
+
+    dataCollector->write(1, ctInt, 1, Selection(Dimensions(1, 1, 1)), "data", &data1);
+    dataCollector->close();
+    // Now file must exist
+    CPPUNIT_ASSERT(fileExists(fullFilename));
+
+    // write second dataset to file (write to existing file of same name
+    dataCollector->open(filename, attr);
+    int data2 = rand();
+
+    dataCollector->write(2, ctInt, 1, Selection(Dimensions(1, 1, 1)), "data", &data2);
+    dataCollector->close();
+
+
+    // read data from file
+    attr.fileAccType = DataCollector::FAT_READ;
+    Dimensions data_size;
+
+    int data = -1;
+    dataCollector->open(filename, attr);
+
+    CPPUNIT_ASSERT(dataCollector->getMaxID() == 2);
+
+    dataCollector->read(1, "data", data_size, &data);
+
+    CPPUNIT_ASSERT(data_size.getScalarSize() == 1);
+    CPPUNIT_ASSERT(data == data1);
+
+    dataCollector->read(2, "data", data_size, &data);
+
+    CPPUNIT_ASSERT(data_size.getScalarSize() == 1);
+    CPPUNIT_ASSERT(data == data2);
+
+    dataCollector->close();
+
+    // erase file
+    attr.fileAccType = DataCollector::FAT_CREATE;
+    dataCollector->open(filename, attr);
+
+    CPPUNIT_ASSERT_THROW(dataCollector->read(1, "data", data_size, &data), DCException);
+    int data3 = rand();
+    dataCollector->write(2, ctInt, 1, Selection(Dimensions(1, 1, 1)), "data", &data3);
+    dataCollector->close();
+
+    // Read from created file
+    attr.fileAccType = DataCollector::FAT_READ;
+
+    data = -1;
+    dataCollector->open(filename, attr);
+
+    CPPUNIT_ASSERT(dataCollector->getMaxID() == 2);
+
+    dataCollector->read(2, "data", data_size, &data);
+
+    CPPUNIT_ASSERT(data_size.getScalarSize() == 1);
+    CPPUNIT_ASSERT(data == data3);
+    dataCollector->close();
+
+    // Cleanup
+    unlink(fullFilename);
+}

--- a/tests/Parallel_FilenameTest.cpp
+++ b/tests/Parallel_FilenameTest.cpp
@@ -1,0 +1,199 @@
+/**
+ * Copyright 2016 Alexander Grund
+ *
+ * This file is part of libSplash.
+ *
+ * libSplash is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * libSplash is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libSplash.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+ 
+ #include <cppunit/extensions/HelperMacros.h>
+
+#include "splash/splash.h"
+#include <mpi.h>
+#include <unistd.h>
+#include <sys/stat.h>
+
+using namespace splash;
+
+class FilenameTest : public CPPUNIT_NS::TestFixture
+{
+    CPPUNIT_TEST_SUITE(FilenameTest);
+
+    CPPUNIT_TEST(testBaseName);
+    CPPUNIT_TEST(testFullName);
+
+    CPPUNIT_TEST_SUITE_END();
+
+public:
+
+    FilenameTest();
+    virtual ~FilenameTest();
+
+private:
+    /**
+     * Tests that file naming is correct when passing only base name
+     */
+    void testBaseName();
+
+    /**
+     * Tests that file naming is correct when passing full name
+     */
+    void testFullName();
+
+    void runTest(const char* filename, const char* fullFilename);
+
+    bool fileExists(const std::string& filename);
+
+    IParallelDataCollector *dataCollector;
+    ColTypeInt ctInt;
+    int mpiRank;
+    static int initCt;
+};
+
+int FilenameTest::initCt = 0;
+
+CPPUNIT_TEST_SUITE_REGISTRATION(FilenameTest);
+
+#define HDF5_FILE "h5/testParallelFilename"
+#define HDF5_BASE_FILE HDF5_FILE "_2.h5"
+#define HDF5_FULL_FILE HDF5_FILE ".h5"
+
+#define MPI_SIZE_X 1
+#define MPI_SIZE_Y 1
+
+FilenameTest::FilenameTest()
+{
+    if(!initCt)
+    {
+        MPI_Init(NULL, NULL);
+        srand(time(NULL));
+        // Remove old files
+        unlink(HDF5_BASE_FILE);
+        unlink(HDF5_FULL_FILE);
+    }
+    initCt++;
+
+    int mpiSize;
+    MPI_Comm_rank(MPI_COMM_WORLD, &mpiRank);
+    MPI_Comm_size(MPI_COMM_WORLD, &mpiSize);
+
+    CPPUNIT_ASSERT(mpiSize == (MPI_SIZE_X * MPI_SIZE_Y));
+
+    dataCollector = new ParallelDataCollector(MPI_COMM_WORLD, MPI_INFO_NULL,
+            Dimensions(MPI_SIZE_X, MPI_SIZE_Y, 1), 1);
+}
+
+FilenameTest::~FilenameTest()
+{
+    if (dataCollector)
+    {
+        dataCollector->finalize();
+        delete dataCollector;
+        dataCollector = NULL;
+    }
+    if(!--initCt)
+        MPI_Finalize();
+}
+
+bool FilenameTest::fileExists(const std::string& filename)
+{
+    struct stat fileInfo;
+    return (stat(filename.c_str(), &fileInfo) == 0);
+}
+
+void FilenameTest::testBaseName()
+{
+    // MPI rank should be appended
+    runTest(HDF5_FILE, HDF5_BASE_FILE);
+}
+
+void FilenameTest::testFullName()
+{
+    // Filename should be used unchanged
+    runTest(HDF5_FULL_FILE, HDF5_FULL_FILE);
+}
+
+void FilenameTest::runTest(const char* filename, const char* fullFilename)
+{
+    CPPUNIT_ASSERT(!fileExists(fullFilename));
+
+    DataCollector::FileCreationAttr attr;
+    DataCollector::initFileCreationAttr(attr);
+    attr.fileAccType = DataCollector::FAT_CREATE;
+
+    // write first dataset to file (create file)
+    dataCollector->open(filename, attr);
+    int data1 = rand();
+
+    dataCollector->write(2, ctInt, 1, Selection(Dimensions(1, 1, 1)), "data1", &data1);
+    dataCollector->close();
+
+    // Now file must exist
+    CPPUNIT_ASSERT(fileExists(fullFilename));
+
+    // write second dataset to file (write to existing file of same name
+    attr.fileAccType = DataCollector::FAT_WRITE;
+    dataCollector->open(filename, attr);
+    int data2 = rand();
+
+    dataCollector->write(2, ctInt, 1, Selection(Dimensions(1, 1, 1)), "data2", &data2);
+    dataCollector->close();
+
+
+    // read data from file
+    attr.fileAccType = DataCollector::FAT_READ;
+    Dimensions data_size;
+
+    int data = -1;
+    dataCollector->open(filename, attr);
+
+    dataCollector->read(2, "data1", data_size, &data);
+
+    CPPUNIT_ASSERT(data_size.getScalarSize() == 1);
+    CPPUNIT_ASSERT(data == data1);
+
+    dataCollector->read(2, "data2", data_size, &data);
+
+    CPPUNIT_ASSERT(data_size.getScalarSize() == 1);
+    CPPUNIT_ASSERT(data == data2);
+
+    dataCollector->close();
+
+    // erase file
+    attr.fileAccType = DataCollector::FAT_CREATE;
+    dataCollector->open(filename, attr);
+
+    CPPUNIT_ASSERT_THROW(dataCollector->read(2, "data1", data_size, &data), DCException);
+    int data3 = rand();
+    dataCollector->write(2, ctInt, 1, Selection(Dimensions(1, 1, 1)), "data1", &data3);
+    dataCollector->close();
+
+
+    data = -1;
+    // Read from created file
+    attr.fileAccType = DataCollector::FAT_READ;
+    dataCollector->open(filename, attr);
+
+    dataCollector->read(2, "data1", data_size, &data);
+
+    CPPUNIT_ASSERT(data_size.getScalarSize() == 1);
+    CPPUNIT_ASSERT(data == data3);
+    dataCollector->close();
+
+    // Cleanup
+    unlink(fullFilename);
+}

--- a/tests/Parallel_FilenameTest.cpp
+++ b/tests/Parallel_FilenameTest.cpp
@@ -70,7 +70,7 @@ CPPUNIT_TEST_SUITE_REGISTRATION(FilenameTest);
 
 #define HDF5_FILE "h5/testParallelFilename"
 #define HDF5_BASE_FILE HDF5_FILE "_2.h5"
-#define HDF5_FULL_FILE HDF5_FILE ".h5"
+#define HDF5_FULL_FILE HDF5_FILE "Full.h5"
 
 #define MPI_SIZE_X 1
 #define MPI_SIZE_Y 1
@@ -193,7 +193,4 @@ void FilenameTest::runTest(const char* filename, const char* fullFilename)
     CPPUNIT_ASSERT(data_size.getScalarSize() == 1);
     CPPUNIT_ASSERT(data == data3);
     dataCollector->close();
-
-    // Cleanup
-    unlink(fullFilename);
 }

--- a/tests/Parallel_SerialDCTest.cpp
+++ b/tests/Parallel_SerialDCTest.cpp
@@ -1,0 +1,253 @@
+/**
+ * Copyright 2016 Alexander Grund
+ *
+ * This file is part of libSplash.
+ *
+ * libSplash is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * libSplash is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libSplash.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+ 
+ #include <cppunit/extensions/HelperMacros.h>
+
+#include "splash/splash.h"
+#include <mpi.h>
+#include <unistd.h>
+#include <sys/stat.h>
+
+using namespace splash;
+
+class FilenameTest : public CPPUNIT_NS::TestFixture
+{
+    CPPUNIT_TEST_SUITE(FilenameTest);
+
+    CPPUNIT_TEST(testBaseName);
+    CPPUNIT_TEST(testFullName);
+
+    CPPUNIT_TEST_SUITE_END();
+
+public:
+
+    FilenameTest();
+    virtual ~FilenameTest();
+
+private:
+    /**
+     * Tests that file naming is correct when passing only base name
+     */
+    void testBaseName();
+
+    /**
+     * Tests that file naming is correct when passing full name
+     */
+    void testFullName();
+
+    bool fileExists(const std::string& filename);
+
+    DataCollector *dataCollector;
+    ColTypeInt ctInt;
+    int mpiRank;
+    static int initCt;
+};
+
+int FilenameTest::initCt = 0;
+
+CPPUNIT_TEST_SUITE_REGISTRATION(FilenameTest);
+
+#define HDF5_FILE "h5/testParallelSerialDC"
+#define HDF5_BASE_FILE HDF5_FILE "_0_0_0.h5"
+#define HDF5_FULL_FILE HDF5_FILE "Full.h5"
+
+#define MPI_SIZE_X 4
+#define MPI_SIZE_Y 2
+
+FilenameTest::FilenameTest()
+{
+    if(!initCt)
+    {
+        MPI_Init(NULL, NULL);
+        srand(time(NULL));
+        // Remove old files
+        unlink(HDF5_BASE_FILE);
+        unlink(HDF5_FULL_FILE);
+    }
+    initCt++;
+
+    int mpiSize;
+    MPI_Comm_rank(MPI_COMM_WORLD, &mpiRank);
+    MPI_Comm_size(MPI_COMM_WORLD, &mpiSize);
+
+    CPPUNIT_ASSERT(mpiSize == (MPI_SIZE_X * MPI_SIZE_Y));
+
+    dataCollector = new SerialDataCollector(10);
+}
+
+FilenameTest::~FilenameTest()
+{
+    if (dataCollector)
+    {
+        delete dataCollector;
+        dataCollector = NULL;
+    }
+    if(!--initCt)
+        MPI_Finalize();
+}
+
+bool FilenameTest::fileExists(const std::string& filename)
+{
+    struct stat fileInfo;
+    return (stat(filename.c_str(), &fileInfo) == 0);
+}
+
+void FilenameTest::testBaseName()
+{
+    // MPI rank should be appended
+    CPPUNIT_ASSERT(!fileExists(HDF5_BASE_FILE));
+
+    // Wait till all checked the above
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    DataCollector::FileCreationAttr attr;
+    DataCollector::initFileCreationAttr(attr);
+    attr.fileAccType = DataCollector::FAT_CREATE;
+    attr.mpiSize = Dimensions(MPI_SIZE_X, MPI_SIZE_Y, 1);
+    attr.mpiPosition = Dimensions(mpiRank % MPI_SIZE_X, mpiRank / MPI_SIZE_X, 0);
+
+    // write first dataset to file (create file)
+    dataCollector->open(HDF5_FILE, attr);
+    int data1 = rand();
+
+    dataCollector->write(2, ctInt, 1, Selection(Dimensions(1, 1, 1)), "data1", &data1);
+    dataCollector->close();
+
+    // Now file must exist
+    CPPUNIT_ASSERT(fileExists(HDF5_BASE_FILE));
+
+    // write second dataset to file (write to existing file of same name
+    attr.fileAccType = DataCollector::FAT_WRITE;
+    dataCollector->open(HDF5_FILE, attr);
+    int data2 = rand();
+
+    dataCollector->write(2, ctInt, 1, Selection(Dimensions(1, 1, 1)), "data2", &data2);
+    dataCollector->close();
+
+
+    // read data from file
+    attr.fileAccType = DataCollector::FAT_READ;
+    Dimensions data_size;
+
+    int data = -1;
+    dataCollector->open(HDF5_FILE, attr);
+
+    dataCollector->read(2, "data1", data_size, &data);
+
+    CPPUNIT_ASSERT(data_size.getScalarSize() == 1);
+    CPPUNIT_ASSERT(data == data1);
+
+    dataCollector->read(2, "data2", data_size, &data);
+
+    CPPUNIT_ASSERT(data_size.getScalarSize() == 1);
+    CPPUNIT_ASSERT(data == data2);
+
+    dataCollector->close();
+
+    // erase file
+    attr.fileAccType = DataCollector::FAT_CREATE;
+    dataCollector->open(HDF5_FILE, attr);
+
+    CPPUNIT_ASSERT_THROW(dataCollector->read(2, "data1", data_size, &data), DCException);
+    int data3 = rand();
+    dataCollector->write(2, ctInt, 1, Selection(Dimensions(1, 1, 1)), "data1", &data3);
+    dataCollector->close();
+
+
+    data = -1;
+    // Read from created file
+    attr.fileAccType = DataCollector::FAT_READ;
+    dataCollector->open(HDF5_FILE, attr);
+
+    dataCollector->read(2, "data1", data_size, &data);
+
+    CPPUNIT_ASSERT(data_size.getScalarSize() == 1);
+    CPPUNIT_ASSERT(data == data3);
+    dataCollector->close();
+}
+
+void FilenameTest::testFullName()
+{
+    // MPI rank should be appended
+    CPPUNIT_ASSERT(!fileExists(HDF5_FULL_FILE));
+
+    // Wait till all checked the above
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    DataCollector::FileCreationAttr attr;
+    DataCollector::initFileCreationAttr(attr);
+    attr.fileAccType = DataCollector::FAT_CREATE;
+    attr.mpiSize = Dimensions(MPI_SIZE_X, MPI_SIZE_Y, 1);
+    attr.mpiPosition = Dimensions(mpiRank % MPI_SIZE_X, mpiRank / MPI_SIZE_X, 0);
+
+    CPPUNIT_ASSERT_THROW(dataCollector->open(HDF5_FULL_FILE, attr), DCException);
+    dataCollector->close();
+    attr.fileAccType = DataCollector::FAT_WRITE;
+    CPPUNIT_ASSERT_THROW(dataCollector->open(HDF5_FULL_FILE, attr), DCException);
+    dataCollector->close();
+
+    int data1, data2;
+    if (mpiRank == 0)
+    {
+        attr.fileAccType = DataCollector::FAT_CREATE;
+        attr.mpiSize = Dimensions(1, 1, 1);
+        dataCollector->open(HDF5_FULL_FILE, attr);
+        data1 = rand();
+
+        dataCollector->write(2, ctInt, 1, Selection(Dimensions(1, 1, 1)), "data1", &data1);
+        dataCollector->close();
+
+        // Now file must exist
+        CPPUNIT_ASSERT(fileExists(HDF5_FULL_FILE));
+
+        // write second dataset to file (write to existing file of same name
+        attr.fileAccType = DataCollector::FAT_WRITE;
+        dataCollector->open(HDF5_FULL_FILE, attr);
+        data2 = rand();
+
+        dataCollector->write(2, ctInt, 1, Selection(Dimensions(1, 1, 1)), "data2", &data2);
+        dataCollector->close();
+        attr.mpiSize = Dimensions(MPI_SIZE_X, MPI_SIZE_Y, 1);
+    }
+    MPI_Bcast(&data1, 1, MPI_INT, 0, MPI_COMM_WORLD);
+    MPI_Bcast(&data2, 1, MPI_INT, 0, MPI_COMM_WORLD);
+
+    // read data from file
+    attr.fileAccType = DataCollector::FAT_READ;
+    Dimensions data_size;
+
+    int data = -1;
+    dataCollector->open(HDF5_FULL_FILE, attr);
+
+    dataCollector->read(2, "data1", data_size, &data);
+
+    CPPUNIT_ASSERT(data_size.getScalarSize() == 1);
+    CPPUNIT_ASSERT(data == data1);
+
+    dataCollector->read(2, "data2", data_size, &data);
+
+    CPPUNIT_ASSERT(data_size.getScalarSize() == 1);
+    CPPUNIT_ASSERT(data == data2);
+
+    dataCollector->close();
+}
+

--- a/tests/run_parallel_tests
+++ b/tests/run_parallel_tests
@@ -53,6 +53,7 @@ function testMPI()
 }
 
 testMPI ./Parallel_SimpleDataTest.cpp.out 8 "Testing simple data read/write (parallel)..."
+testMPI ./Parallel_FilenameTest.cpp.out 1 "Testing file naming (parallel)..."
 
 testMPI ./Parallel_ListFilesTest.cpp.out 1 "Testing list files (parallel)..."
 

--- a/tests/run_parallel_tests
+++ b/tests/run_parallel_tests
@@ -55,6 +55,8 @@ function testMPI()
 testMPI ./Parallel_SimpleDataTest.cpp.out 8 "Testing simple data read/write (parallel)..."
 testMPI ./Parallel_FilenameTest.cpp.out 1 "Testing file naming (parallel)..."
 
+testMPI ./Parallel_SerialDC.cpp.out 8 "Testing SerialDataCollector (parallel)..."
+
 testMPI ./Parallel_ListFilesTest.cpp.out 1 "Testing list files (parallel)..."
 
 testMPI ./Parallel_DomainsTest.cpp.out 8 "Testing domains (parallel)..."

--- a/tests/run_tests
+++ b/tests/run_tests
@@ -63,6 +63,7 @@ function testMPI()
 }
 
 testSerial ./SimpleDataTest.cpp.out "Testing simple data read/write..."
+testSerial ./FilenameTest.cpp.out "Testing file naming..."
 
 testSerial ./AttributesTest.cpp.out "Testing reading/writing attributes..."
 testSerial ./readBoolChar.py "Testing h5py compatible read..."


### PR DESCRIPTION
Allows passing full name to SerialDataCollector

Previously the SerialDataCollector created names like "foo.h5_0_0_0.h5" , this is now kept as "foo.h5"

For this it also changes the HandleMgr and extends its filename scheme by FNS_FULLNAME where the name is kept unchanged. Additionally checks where added for catching erroneously passing a full name into the DataCollectors when a base name was expected.

From #234