### PR TITLE
Fix comparison and docu of generateCollectionType

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,17 +20,17 @@ env:
 script:
   - cd $BUILD
 # compile libSplash and install
-  - cmake -DTOOLS_MPI=$SPLASHMPI $SRC
+  - cmake -DCMAKE_BUILD_TYPE=Debug -DTOOLS_MPI=$SPLASHMPI $SRC
   - make package
   - sudo dpkg -i libsplash*.deb
   - ls -hal /usr/share/pyshared/
   - rm -rf $BUILD/*
 # compile examples/
-  - cmake -DWITH_MPI=$SPLASHMPI $SRC/examples
+  - cmake -DCMAKE_BUILD_TYPE=Debug -DWITH_MPI=$SPLASHMPI $SRC/examples
   - make
   - rm -rf $BUILD/*
 # compile and run tests/
-  - cmake -DWITH_MPI=$SPLASHMPI $SRC/tests
+  - cmake -DCMAKE_BUILD_TYPE=Debug -DWITH_MPI=$SPLASHMPI $SRC/tests
   - make
 # run tests
   - $SRC/tests/run_tests $BUILD

--- a/src/include/splash/basetypes/generateCollectionType.hpp
+++ b/src/include/splash/basetypes/generateCollectionType.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015 Carlchristian Eckert
+ * Copyright 2015-2016 Carlchristian Eckert, Alexander Grund
  *
  * This file is part of libSplash.
  *
@@ -32,7 +32,7 @@ namespace splash
 
 /**
  * Checks if a datatype_id (from an outer scope) can be used to generate a
- * specific CollectionType derivate.
+ * specific CollectionType instance.
  *
  * If the call to the genType member function of a specific collection type
  * is successful, it will return the pointer to an instance of this type.
@@ -44,6 +44,7 @@ namespace splash
 {                                                                              \
     CollectionType* t = ColType##_name::genType(datatype_id);                  \
     if(t != NULL && typeid(*t) == typeid(ColType##_name)) return t;            \
+    delete t;                                                                  \
 }                                                                              \
 
 
@@ -53,10 +54,11 @@ namespace splash
  * @param datatype_id the H5 datatype_id that should be converted into a
  *                    CollectionType
  *
- * @return A pointer to a heap-allocated CollectionType, if a matching
- *         CollectionType could be determined. The allocated object must be
- *         freed by the caller at the end of its lifetime.
- *         If no matching CollectionType was found, returns NULL.
+ * @return A pointer to a heap-allocated CollectionType.
+ *         The allocated object must be freed by the caller at the end of its
+ *         lifetime.
+ *         If no matching CollectionType was found, returns a ColTypeUnknown
+ *         instance.
  */
 CollectionType* generateCollectionType(hid_t datatype_id)
 {
@@ -123,6 +125,7 @@ CollectionType* generateCollectionType(hid_t datatype_id)
     return new ColTypeUnknown;
 }
 
+#undef TRY_COLTYPE
 
 } /* namespace splash */
 

--- a/src/include/splash/basetypes/generateCollectionType.hpp
+++ b/src/include/splash/basetypes/generateCollectionType.hpp
@@ -43,8 +43,8 @@ namespace splash
 #define TRY_COLTYPE(_name)                                                     \
 {                                                                              \
     CollectionType* t = ColType##_name::genType(datatype_id);                  \
-    if(t != NULL && typeid(*t) == typeid(ColType##_name)) return t;            \
-    delete t;                                                                  \
+    assert(t == NULL || typeid(*t) == typeid(ColType##_name));                 \
+    if(t) return t;                                                            \
 }                                                                              \
 
 

--- a/src/include/splash/basetypes/generateCollectionType.hpp
+++ b/src/include/splash/basetypes/generateCollectionType.hpp
@@ -44,7 +44,7 @@ namespace splash
 {                                                                              \
     CollectionType* t = ColType##_name::genType(datatype_id);                  \
     assert(t == NULL || typeid(*t) == typeid(ColType##_name));                 \
-    if(t) return t;                                                            \
+    if(t != NULL) return t;                                                    \
 }                                                                              \
 
 


### PR DESCRIPTION
The function returns `ColTypeUnknown` on not-found.
Also the typeid check is superfluous as the static function `genType` of that type should per definition return an instance of itself. An assertion is added instead.

In case new `genType`'s are implemented, this will guarantee that no mem-leaks can occur.