### PR TITLE
Throw exception on invalid calls

### DIFF
--- a/src/ParallelDataCollector.cpp
+++ b/src/ParallelDataCollector.cpp
@@ -770,33 +770,6 @@ namespace splash
         src_dataset.close();
     }
 
-    void ParallelDataCollector::createReference(int32_t srcID,
-            const char *srcName,
-            int32_t dstID,
-            const char *dstName,
-            Dimensions /*count*/,
-            Dimensions /*offset*/,
-            Dimensions /*stride*/)
-    throw (DCException)
-    {
-        if (srcName == NULL || dstName == NULL)
-            throw DCException(getExceptionString("createReference", "a parameter was NULL"));
-
-        if (fileStatus == FST_CLOSED || fileStatus == FST_READING)
-            throw DCException(getExceptionString("createReference", "this access is not permitted"));
-
-        if (srcID != dstID)
-            throw DCException(getExceptionString("createReference",
-                "source and destination ID must be identical", NULL));
-
-        if (srcName == dstName)
-            throw DCException(getExceptionString("createReference",
-                "a reference must not be identical to the referenced data", srcName));
-
-        throw DCException(getExceptionString("createReference",
-                "feature currently not supported by Parallel HDF5", NULL));
-    }
-
     /*******************************************************************************
      * PROTECTED FUNCTIONS
      *******************************************************************************/
@@ -1137,6 +1110,58 @@ namespace splash
         dataset.create(type, group.getHandle(), globalSize, ndims,
                 this->options.enableCompression, true);
         dataset.close();
+    }
+
+    /* UNIMPLEMENTED METHODS FROM DATACOLLECTOR. TODO: Unify interface to remove those */
+    void ParallelDataCollector::readGlobalAttribute(const char*, void*, Dimensions*)
+    throw (DCException)
+    {
+        throw DCException(getExceptionString("readGlobalAttribute",
+                "feature currently not supported by Parallel HDF5"));
+    }
+
+    void ParallelDataCollector::writeGlobalAttribute(const CollectionType& /*type*/,
+            const char* /*name*/, const void* /*data*/) throw (DCException)
+    {
+        throw DCException(getExceptionString("readGlobalAttribute",
+                "feature currently not supported by Parallel HDF5"));
+    }
+
+    void ParallelDataCollector::writeGlobalAttribute(const CollectionType& /*type*/,
+            const char* /*name*/, uint32_t /*ndims*/, const Dimensions /*dims*/,
+            const void* /*data*/) throw (DCException)
+    {
+        throw DCException(getExceptionString("readGlobalAttribute",
+                "feature currently not supported by Parallel HDF5"));
+    }
+
+    void ParallelDataCollector::append(int32_t /*id*/, const CollectionType& /*type*/,
+            size_t /*count*/, const char* /*name*/, const void* /*data*/)
+    throw (DCException)
+    {
+        throw DCException(getExceptionString("readGlobalAttribute",
+                "feature currently not supported by Parallel HDF5"));
+    }
+
+    void ParallelDataCollector::append(int32_t /*id*/, const CollectionType& /*type*/,
+            size_t /*count*/, size_t /*offset*/, size_t /*stride*/, const char* /*name*/,
+            const void* /*data*/) throw (DCException)
+    {
+        throw DCException(getExceptionString("readGlobalAttribute",
+                "feature currently not supported by Parallel HDF5"));
+    }
+
+    void ParallelDataCollector::createReference(int32_t /*srcID*/,
+            const char */*srcName*/,
+            int32_t /*dstID*/,
+            const char */*dstName*/,
+            Dimensions /*count*/,
+            Dimensions /*offset*/,
+            Dimensions /*stride*/)
+    throw (DCException)
+    {
+        throw DCException(getExceptionString("readGlobalAttribute",
+                "feature currently not supported by Parallel HDF5"));
     }
 
 }

--- a/src/include/splash/ParallelDataCollector.hpp
+++ b/src/include/splash/ParallelDataCollector.hpp
@@ -355,37 +355,27 @@ namespace splash
 
     private:
 
+        /* Invalid methods from DataCollector. Do NOT call! */
+
         void readGlobalAttribute(const char*,
                 void*,
-                Dimensions*)
-        {
-
-        }
+                Dimensions*) throw (DCException);
 
         void writeGlobalAttribute(const CollectionType& /*type*/,
                 const char* /*name*/,
-                const void* /*data*/)
-        {
-
-        }
+                const void* /*data*/) throw (DCException);
 
         void writeGlobalAttribute(const CollectionType& /*type*/,
                 const char* /*name*/,
                 uint32_t /*ndims*/,
                 const Dimensions /*dims*/,
-                const void* /*data*/)
-        {
-
-        }
+                const void* /*data*/) throw (DCException);
 
         void append(int32_t /*id*/,
                 const CollectionType& /*type*/,
                 size_t /*count*/,
                 const char* /*name*/,
-                const void* /*data*/)
-        {
-
-        }
+                const void* /*data*/) throw (DCException);
 
         void append(int32_t /*id*/,
                 const CollectionType& /*type*/,
@@ -393,10 +383,7 @@ namespace splash
                 size_t /*offset*/,
                 size_t /*stride*/,
                 const char* /*name*/,
-                const void* /*data*/)
-        {
-
-        }
+                const void* /*data*/) throw (DCException);
 
         void createReference(int32_t /*srcID*/,
                 const char* /*srcName*/,
@@ -406,6 +393,7 @@ namespace splash
                 Dimensions /*offset*/,
                 Dimensions /*stride*/) throw (DCException);
 
+        /* End invalid methods */
 
         /**
          * Internal meta data reading method.

--- a/src/include/splash/basetypes/ColTypeDimArray.hpp
+++ b/src/include/splash/basetypes/ColTypeDimArray.hpp
@@ -36,7 +36,7 @@ namespace splash
 
         ColTypeDimArray()
         {
-            const hsize_t dim[] = {3};
+            const hsize_t dim[] = {DSP_DIM_MAX};
             this->type = H5Tarray_create(H5T_NATIVE_HSIZE, 1, dim);
         }
 


### PR DESCRIPTION
This adds exception throwing for the invalid methods of ParallelDC.

I just run into an issue accidentally using one of them, which is pretty annoying.