### PR TITLE
Attribute meta info

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,7 +87,7 @@ UNSET(HDF5_HAS_SHARED_POS)
 
 #-------------------------------------------------------------------------------
 
-SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Woverloaded-virtual -Wno-deprecated-declarations")
+SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Woverloaded-virtual")
 
 # options
 OPTION(DEBUG_VERBOSE "Enable verbose HDF5 debug output" OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,7 +112,7 @@ SET(SPLASH_LIBS z ${HDF5_LIBRARIES})
 
 # serial or parallel version of libSplash
 SET(SPLASH_CLASSES logging DCAttribute DCDataSet DCGroup HandleMgr SerialDataCollector
-    DomainCollector SDCHelper DCAttributeInfo generateCollectionType)
+    DomainCollector SDCHelper AttributeInfo generateCollectionType)
 IF(HDF5_IS_PARALLEL)
     #parallel version
     MESSAGE(STATUS "Parallel HDF5 found. Building parallel version")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,7 +112,7 @@ SET(SPLASH_LIBS z ${HDF5_LIBRARIES})
 
 # serial or parallel version of libSplash
 SET(SPLASH_CLASSES logging DCAttribute DCDataSet DCGroup HandleMgr SerialDataCollector
-    DomainCollector SDCHelper generateCollectionType)
+    DomainCollector SDCHelper DCAttributeInfo generateCollectionType)
 IF(HDF5_IS_PARALLEL)
     #parallel version
     MESSAGE(STATUS "Parallel HDF5 found. Building parallel version")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,7 +87,7 @@ UNSET(HDF5_HAS_SHARED_POS)
 
 #-------------------------------------------------------------------------------
 
-SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Woverloaded-virtual")
+SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Woverloaded-virtual -Wno-deprecated-declarations")
 
 # options
 OPTION(DEBUG_VERBOSE "Enable verbose HDF5 debug output" OFF)

--- a/src/AttributeInfo.cpp
+++ b/src/AttributeInfo.cpp
@@ -20,7 +20,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "splash/DCAttributeInfo.hpp"
+#include "splash/AttributeInfo.hpp"
 #include "splash/CollectionType.hpp"
 #include "splash/basetypes/generateCollectionType.hpp"
 #include <cassert>
@@ -29,22 +29,22 @@
 namespace splash
 {
 
-DCAttributeInfo::DCAttributeInfo(hid_t attr): attr_(attr), colType_(NULL)
+AttributeInfo::AttributeInfo(hid_t attr): attr_(attr), colType_(NULL)
 {
 }
 
-DCAttributeInfo::~DCAttributeInfo()
+AttributeInfo::~AttributeInfo()
 {
     delete colType_;
 }
 
-std::string DCAttributeInfo::getExceptionString(const std::string& msg)
+std::string AttributeInfo::getExceptionString(const std::string& msg)
 {
     return (std::string("Exception for DCAttribute [") + readName() +
             std::string("] ") + msg);
 }
 
-inline void DCAttributeInfo::loadType() throw(DCException)
+inline void AttributeInfo::loadType() throw(DCException)
 {
     if(!type_)
     {
@@ -54,7 +54,7 @@ inline void DCAttributeInfo::loadType() throw(DCException)
     }
 }
 
-inline void DCAttributeInfo::loadSpace() throw(DCException)
+inline void AttributeInfo::loadSpace() throw(DCException)
 {
     if(!space_)
     {
@@ -77,7 +77,7 @@ inline void DCAttributeInfo::loadSpace() throw(DCException)
     }
 }
 
-std::string DCAttributeInfo::readName()
+std::string AttributeInfo::readName()
 {
     ssize_t nameLen = H5Aget_name(attr_, 0, NULL);
     if(nameLen <= 0)
@@ -91,7 +91,7 @@ std::string DCAttributeInfo::readName()
     return strName;
 }
 
-size_t DCAttributeInfo::getMemSize() throw(DCException)
+size_t AttributeInfo::getMemSize() throw(DCException)
 {
     loadType();
     // For variable length strings the storage size is always the size of 2 pointers
@@ -107,7 +107,7 @@ size_t DCAttributeInfo::getMemSize() throw(DCException)
     }
 }
 
-const CollectionType& DCAttributeInfo::getType() throw(DCException)
+const CollectionType& AttributeInfo::getType() throw(DCException)
 {
     if(!colType_)
     {
@@ -117,7 +117,7 @@ const CollectionType& DCAttributeInfo::getType() throw(DCException)
     return *colType_;
 }
 
-Dimensions DCAttributeInfo::getDims() throw(DCException)
+Dimensions AttributeInfo::getDims() throw(DCException)
 {
     loadSpace();
     Dimensions dims(1, 1, 1);
@@ -135,31 +135,31 @@ Dimensions DCAttributeInfo::getDims() throw(DCException)
     return dims;
 }
 
-uint32_t DCAttributeInfo::getNDims() throw(DCException)
+uint32_t AttributeInfo::getNDims() throw(DCException)
 {
     loadSpace();
     // A value of 0 means a scalar, treat as 1D
     return nDims_ == 0 ? 1 : nDims_;
 }
 
-bool DCAttributeInfo::isVarSize() throw(DCException)
+bool AttributeInfo::isVarSize() throw(DCException)
 {
     loadType();
     return H5Tis_variable_str(type_);
 }
 
-void DCAttributeInfo::read(const CollectionType& colType, void* buf) throw(DCException)
+void AttributeInfo::read(const CollectionType& colType, void* buf) throw(DCException)
 {
     if(!readNoThrow(colType, buf))
         throw DCException(getExceptionString("Could not read or convert data"));
 }
 
-bool DCAttributeInfo::readNoThrow(const CollectionType& colType, void* buf)
+bool AttributeInfo::readNoThrow(const CollectionType& colType, void* buf)
 {
     return H5Aread(attr_, colType.getDataType(), buf) >= 0;
 }
 
-void DCAttributeInfo::read(void* buf, size_t bufSize) throw(DCException)
+void AttributeInfo::read(void* buf, size_t bufSize) throw(DCException)
 {
     loadType();
     if(getMemSize() != bufSize)

--- a/src/AttributeInfo.cpp
+++ b/src/AttributeInfo.cpp
@@ -193,6 +193,12 @@ void AttributeInfo::read(void* buf, size_t bufSize) throw(DCException)
         throw DCException(getExceptionString("Could not read data"));
 }
 
+void AttributeInfo::close()
+{
+    AttributeInfo tmp(-1);
+    swap(*this, tmp);
+}
+
 void swap(AttributeInfo& lhs, AttributeInfo& rhs)
 {
     using std::swap;

--- a/src/DCAttribute.cpp
+++ b/src/DCAttribute.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013, 2015 Felix Schmitt, Axel Huebl
+ * Copyright 2013-2016 Felix Schmitt, Axel Huebl, Alexander Grund
  *
  * This file is part of libSplash.
  *
@@ -20,77 +20,117 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-
-
-#include <sstream>
-
 #include "splash/core/DCAttribute.hpp"
+#include "splash/core/H5IdWrapper.hpp"
+#include "splash/DCAttributeInfo.hpp"
+#include "splash/basetypes/generateCollectionType.hpp"
+
+#include <cassert>
 
 namespace splash
 {
-
-    DCAttribute::DCAttribute()
-    {
-    }
-
     std::string DCAttribute::getExceptionString(const char *name, std::string msg)
     {
         return (std::string("Exception for DCAttribute [") + std::string(name) +
                 std::string("] ") + msg);
     }
 
+    DCAttributeInfo* DCAttribute::readAttributeInfo(const char* name, hid_t parent)
+    throw (DCException)
+    {
+        H5AttributeId attr(H5Aopen(parent, name, H5P_DEFAULT));
+        if (!attr)
+            throw DCException(getExceptionString(name, "Attribute could not be opened for reading"));
+
+        H5TypeId attrType(H5Aget_type(attr));
+        if (!attrType)
+            throw DCException(getExceptionString(name, "Could not get type of attribute"));
+
+        H5DataspaceId attrSpace(H5Aget_space(attr));
+        if (!attrSpace)
+            throw DCException(getExceptionString(name, "Could not get dataspace of attribute"));
+        // Currently only simple dataspaces exist and are supported by this library
+        if (!H5Sis_simple(attrSpace) > 0)
+            throw DCException(getExceptionString(name, "Dataspace is not simple"));
+
+        // For scalars we don't need more info on the dataspace
+        H5S_class_t spaceClass = H5Sget_simple_extent_type(attrSpace);
+        int nDims = 1;
+        hsize_t dims[DSP_DIM_MAX];
+        if (spaceClass != H5S_SCALAR)
+        {
+            nDims = H5Sget_simple_extent_ndims(attrSpace);
+            if (nDims < 0)
+                throw DCException(getExceptionString(name, "Could not get dimensionality of dataspace"));
+            if (nDims > DSP_DIM_MAX)
+                throw DCException(getExceptionString(name, "Dimensionality of dataspace is greater than the maximum supported value"));
+            int nDims2 = H5Sget_simple_extent_dims(attrSpace, dims, NULL);
+            if (nDims2 != nDims)
+                throw DCException(getExceptionString(name, "Could not get dimensions of dataspace"));
+        }
+
+        DCAttributeInfo* result = new DCAttributeInfo;
+        result->colType_ = generateCollectionType(attrType);
+        // There is also H5Aget_storage_size(attr), but that returns the size of 2 pointers
+        // for variable length strings instead of 1
+        result->memSize_ = H5Tget_size(attrType);
+
+        if (spaceClass == H5S_SCALAR)
+        {
+            result->ndims_ = 1;
+        }else
+        {
+            result->ndims_ = nDims;
+            for (int i = 0; i < nDims; i++)
+                result->dims_[i] = dims[i];
+            // Each element takes up the storage of the type
+            result->memSize_ *= result->dims_.getScalarSize();
+            // Normally this should be the same as the storage size.
+            // So we can probably use that if this works for all cases
+            assert(result->memSize_ == H5Aget_storage_size(attr));
+        }
+
+        return result;
+    }
+
     void DCAttribute::readAttribute(const char* name, hid_t parent, void* dst)
     throw (DCException)
     {
-        hid_t attr = H5Aopen(parent, name, H5P_DEFAULT);
-        if (attr < 0)
+        H5AttributeId attr(H5Aopen(parent, name, H5P_DEFAULT));
+        if (!attr)
             throw DCException(getExceptionString(name, "Attribute could not be opened for reading"));
 
-        hid_t attr_type = H5Aget_type(attr);
-        if (attr_type < 0)
-        {
-            H5Aclose(attr);
+        H5TypeId attr_type(H5Aget_type(attr));
+        if (!attr_type)
             throw DCException(getExceptionString(name, "Could not get type of attribute"));
-        }
 
         if (H5Aread(attr, attr_type, dst) < 0)
-        {
-            H5Aclose(attr);
             throw DCException(getExceptionString(name, "Attribute could not be read"));
-        }
-
-        H5Aclose(attr);
     }
 
     void DCAttribute::writeAttribute(const char* name, const hid_t type, hid_t parent,
                                      uint32_t ndims, const Dimensions dims, const void* src)
     throw (DCException)
     {
-        hid_t attr = -1;
+        H5AttributeId attr;
         if (H5Aexists(parent, name))
-            attr = H5Aopen(parent, name, H5P_DEFAULT);
+            attr.reset(H5Aopen(parent, name, H5P_DEFAULT));
         else
         {
-            hid_t dsp;
+            H5DataspaceId dsp;
             if( ndims == 1 && dims.getScalarSize() == 1 )
-                dsp = H5Screate(H5S_SCALAR);
+                dsp.reset(H5Screate(H5S_SCALAR));
             else
-                dsp = H5Screate_simple( ndims, dims.getPointer(), dims.getPointer() );
+                dsp.reset(H5Screate_simple( ndims, dims.getPointer(), dims.getPointer() ));
 
-            attr = H5Acreate(parent, name, type, dsp, H5P_DEFAULT, H5P_DEFAULT);
-            H5Sclose(dsp);
+            attr.reset(H5Acreate(parent, name, type, dsp, H5P_DEFAULT, H5P_DEFAULT));
         }
 
-        if (attr < 0)
+        if (!attr)
             throw DCException(getExceptionString(name, "Attribute could not be opened or created"));
 
         if (H5Awrite(attr, type, src) < 0)
-        {
-            H5Aclose(attr);
             throw DCException(getExceptionString(name, "Attribute could not be written"));
-        }
-
-        H5Aclose(attr);
     }
 
     void DCAttribute::writeAttribute(const char* name, const hid_t type, hid_t parent, const void* src)

--- a/src/DCAttribute.cpp
+++ b/src/DCAttribute.cpp
@@ -20,10 +20,9 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "splash/AttributeInfo.hpp"
 #include "splash/core/DCAttribute.hpp"
 #include "splash/core/H5IdWrapper.hpp"
-#include "splash/DCAttributeInfo.hpp"
-
 #include <cassert>
 
 namespace splash
@@ -34,13 +33,13 @@ namespace splash
                 std::string("] ") + msg);
     }
 
-    DCAttributeInfo* DCAttribute::readAttributeInfo(const char* name, hid_t parent)
+    AttributeInfo* DCAttribute::readAttributeInfo(const char* name, hid_t parent)
     throw (DCException)
     {
         H5AttributeId attr(H5Aopen(parent, name, H5P_DEFAULT));
         if (!attr)
             throw DCException(getExceptionString(name, "Attribute could not be opened for reading"));
-        return new DCAttributeInfo(attr.release());
+        return new AttributeInfo(attr.release());
     }
 
     void DCAttribute::readAttribute(const char* name, hid_t parent, void* dst)

--- a/src/DCAttribute.cpp
+++ b/src/DCAttribute.cpp
@@ -37,10 +37,10 @@ namespace splash
     DCAttributeInfo* DCAttribute::readAttributeInfo(const char* name, hid_t parent)
     throw (DCException)
     {
-        hid_t attr = H5Aopen(parent, name, H5P_DEFAULT);
+        H5AttributeId attr(H5Aopen(parent, name, H5P_DEFAULT));
         if (!attr)
             throw DCException(getExceptionString(name, "Attribute could not be opened for reading"));
-        return new DCAttributeInfo(attr);
+        return new DCAttributeInfo(attr.release());
     }
 
     void DCAttribute::readAttribute(const char* name, hid_t parent, void* dst)

--- a/src/DCAttribute.cpp
+++ b/src/DCAttribute.cpp
@@ -50,7 +50,7 @@ namespace splash
         if (!attrSpace)
             throw DCException(getExceptionString(name, "Could not get dataspace of attribute"));
         // Currently only simple dataspaces exist and are supported by this library
-        if (!H5Sis_simple(attrSpace) > 0)
+        if (H5Sis_simple(attrSpace) <= 0)
             throw DCException(getExceptionString(name, "Dataspace is not simple"));
 
         // For scalars we don't need more info on the dataspace
@@ -74,6 +74,7 @@ namespace splash
         // There is also H5Aget_storage_size(attr), but that returns the size of 2 pointers
         // for variable length strings instead of 1
         result->memSize_ = H5Tget_size(attrType);
+        result->isVarSize_ = H5Tis_variable_str(attrType);
 
         if (spaceClass == H5S_SCALAR)
         {

--- a/src/DCAttribute.cpp
+++ b/src/DCAttribute.cpp
@@ -59,7 +59,7 @@ namespace splash
     }
 
     void DCAttribute::writeAttribute(const char* name, const hid_t type, hid_t parent,
-                                     uint32_t ndims, const Dimensions dims, const void* src)
+                                     uint32_t ndims, Dimensions dims, const void* src)
     throw (DCException)
     {
         H5AttributeId attr;
@@ -67,6 +67,7 @@ namespace splash
             attr.reset(H5Aopen(parent, name, H5P_DEFAULT));
         else
         {
+            dims.swapDims(ndims);
             H5DataspaceId dsp;
             if( ndims == 1 && dims.getScalarSize() == 1 )
                 dsp.reset(H5Screate(H5S_SCALAR));

--- a/src/DCAttribute.cpp
+++ b/src/DCAttribute.cpp
@@ -33,13 +33,13 @@ namespace splash
                 std::string("] ") + msg);
     }
 
-    AttributeInfo* DCAttribute::readAttributeInfo(const char* name, hid_t parent)
+    AttributeInfo DCAttribute::readAttributeInfo(const char* name, hid_t parent)
     throw (DCException)
     {
         H5AttributeId attr(H5Aopen(parent, name, H5P_DEFAULT));
         if (!attr)
             throw DCException(getExceptionString(name, "Attribute could not be opened for reading"));
-        return new AttributeInfo(attr.release());
+        return AttributeInfo(attr);
     }
 
     void DCAttribute::readAttribute(const char* name, hid_t parent, void* dst)

--- a/src/DCAttributeInfo.cpp
+++ b/src/DCAttributeInfo.cpp
@@ -24,6 +24,7 @@
 #include "splash/CollectionType.hpp"
 #include "splash/basetypes/generateCollectionType.hpp"
 #include <cassert>
+#include <sstream>
 
 namespace splash
 {
@@ -162,7 +163,11 @@ void DCAttributeInfo::read(void* buf, size_t bufSize) throw(DCException)
 {
     loadType();
     if(getMemSize() != bufSize)
-        throw DCException(getExceptionString("Buffer size does not match attribute size"));
+    {
+        std::stringstream ss;
+        ss << "Buffer size (" << bufSize << ") does not match attribute size (" << getMemSize() << ")";
+        throw DCException(getExceptionString(ss.str()));
+    }
     if(H5Aread(attr_, type_, buf) < 0)
         throw DCException(getExceptionString("Could not read data"));
 }

--- a/src/DCAttributeInfo.cpp
+++ b/src/DCAttributeInfo.cpp
@@ -129,6 +129,7 @@ Dimensions DCAttributeInfo::getDims() throw(DCException)
         // Conversion to int is save due to limited range
         if (nDims2 != static_cast<int>(nDims_))
             throw DCException(getExceptionString("Could not get dimensions of dataspace"));
+        dims.swapDims(nDims_);
     }
     return dims;
 }

--- a/src/DCAttributeInfo.cpp
+++ b/src/DCAttributeInfo.cpp
@@ -22,16 +22,109 @@
 
 #include "splash/DCAttributeInfo.hpp"
 #include "splash/CollectionType.hpp"
+#include "splash/DCException.hpp"
+#include "splash/basetypes/generateCollectionType.hpp"
+#include <cassert>
 
 namespace splash
 {
 
-    DCAttributeInfo::DCAttributeInfo(): colType_(NULL)
-    {
-    }
+DCAttributeInfo::DCAttributeInfo(hid_t attr): attr_(attr), colType_(NULL)
+{
+}
 
-    DCAttributeInfo::~DCAttributeInfo()
+DCAttributeInfo::~DCAttributeInfo()
+{
+    delete colType_;
+}
+
+inline void DCAttributeInfo::loadType()
+{
+    if(!type_)
     {
-        delete colType_;
+        type_.reset(H5Aget_type(attr_));
+        if (!type_)
+            throw DCException("Could not get type of attribute");
     }
+}
+
+inline void DCAttributeInfo::loadSpace()
+{
+    if(!space_)
+    {
+        space_.reset(H5Aget_space(attr_));
+        if (!space_)
+            throw DCException("Could not get dataspace of attribute");
+        // Currently only simple dataspaces exist and are supported by this library
+        if (H5Sis_simple(space_) <= 0)
+            throw DCException("Dataspace is not simple");
+        H5S_class_t spaceClass = H5Sget_simple_extent_type(space_);
+        if (spaceClass == H5S_SCALAR)
+            nDims_ = 0;
+        else
+        {
+            int nDims = H5Sget_simple_extent_ndims(space_);
+            if (nDims < 0)
+                throw DCException("Could not get dimensionality of dataspace");
+            nDims_ = static_cast<uint32_t>(nDims);
+        }
+    }
+}
+
+size_t DCAttributeInfo::getMemSize()
+{
+    loadType();
+    // For variable length strings the storage size is always the size of 2 pointers
+    // So we need the types size for that
+    if(H5Tis_variable_str(type_))
+        return H5Tget_size(type_);
+    else
+    {
+        size_t result = H5Aget_storage_size(attr_);
+        // This should be the same, but the above does not require getting the dims
+        assert(result == H5Tget_size(type_) * getDims().getScalarSize());
+        return result;
+    }
+}
+
+const CollectionType& DCAttributeInfo::getType()
+{
+    if(!colType_)
+    {
+        loadType();
+        colType_ = generateCollectionType(type_);
+    }
+    return *colType_;
+}
+
+Dimensions DCAttributeInfo::getDims()
+{
+    loadSpace();
+    Dimensions dims(1, 1, 1);
+    // For scalars we don't need more info on the dataspace
+    if (nDims_ > 0)
+    {
+        if (nDims_ > DSP_DIM_MAX)
+            throw DCException("Dimensionality of dataspace is greater than the maximum supported value");
+        int nDims2 = H5Sget_simple_extent_dims(space_, dims.getPointer(), NULL);
+        // Conversion to int is save due to limited range
+        if (nDims2 != static_cast<int>(nDims_))
+            throw DCException("Could not get dimensions of dataspace");
+    }
+    return dims;
+}
+
+uint32_t DCAttributeInfo::getNDims()
+{
+    loadSpace();
+    // A value of 0 means a scalar, treat as 1D
+    return nDims_ == 0 ? 1 : nDims_;
+}
+
+bool DCAttributeInfo::isVarSize()
+{
+    loadType();
+    return H5Tis_variable_str(type_);
+}
+
 }

--- a/src/DCAttributeInfo.cpp
+++ b/src/DCAttributeInfo.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Felix Schmitt
+ * Copyright 2016 Alexander Grund
  *
  * This file is part of libSplash.
  *
@@ -20,17 +20,18 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef SPLASH_H
-#define SPLASH_H
-
-#define SPLASH_SUPPORTED_SERIAL 1
-
-#include "splash/version.hpp"
-
-#include "splash/SerialDataCollector.hpp"
-#include "splash/DomainCollector.hpp"
-
-#include "splash/basetypes/basetypes.hpp"
 #include "splash/DCAttributeInfo.hpp"
+#include "splash/CollectionType.hpp"
 
-#endif /* SPLASH_H */
+namespace splash
+{
+
+    DCAttributeInfo::DCAttributeInfo(): colType_(NULL)
+    {
+    }
+
+    DCAttributeInfo::~DCAttributeInfo()
+    {
+        delete colType_;
+    }
+}

--- a/src/DomainCollector.cpp
+++ b/src/DomainCollector.cpp
@@ -82,8 +82,8 @@ namespace splash
         Dimensions domain_size;
         Dimensions domain_offset;
 
-        readAttribute(id, name, DOMCOL_ATTR_SIZE, domain_size.getPointer(), &mpi_position);
-        readAttribute(id, name, DOMCOL_ATTR_OFFSET, domain_offset.getPointer(), &mpi_position);
+        readAttributeInfo(id, name, DOMCOL_ATTR_SIZE, &mpi_position).read(domain_size.getPointer(), domain_size.getSize());
+        readAttributeInfo(id, name, DOMCOL_ATTR_OFFSET, &mpi_position).read(domain_offset.getPointer(), domain_offset.getSize());
 
         return Domain(domain_offset, domain_size);
     }
@@ -792,11 +792,11 @@ namespace splash
     {
         try
         {
-            readAttribute(id, dataName, DOMCOL_ATTR_GLOBAL_SIZE, data, mpiPosition);
+            readAttributeInfo(id, dataName, DOMCOL_ATTR_GLOBAL_SIZE, mpiPosition).read(data, sizeof(*data) * DSP_DIM_MAX);
         } catch (const DCException&)
         {
             hsize_t local_size[DSP_DIM_MAX];
-            readAttribute(id, dataName, DOMCOL_ATTR_SIZE, local_size, mpiPosition);
+            readAttributeInfo(id, dataName, DOMCOL_ATTR_SIZE, mpiPosition).read(local_size, sizeof(local_size));
 
             for (int i = 0; i < DSP_DIM_MAX; ++i)
                 data[i] = mpiTopology[i] * local_size[i];
@@ -811,7 +811,7 @@ namespace splash
     {
         try
         {
-            readAttribute(id, dataName, DOMCOL_ATTR_GLOBAL_OFFSET, data, mpiPosition);
+            readAttributeInfo(id, dataName, DOMCOL_ATTR_GLOBAL_OFFSET, mpiPosition).read(data, sizeof(*data) * DSP_DIM_MAX);
         } catch (const DCException&)
         {
             for (int i = 0; i < DSP_DIM_MAX; ++i)

--- a/src/ParallelDataCollector.cpp
+++ b/src/ParallelDataCollector.cpp
@@ -1037,7 +1037,7 @@ namespace splash
             }
 
         if(entry_id < 0)
-            throw DCException(getExceptionString("readDataSetMeta", "Entry not found by name"));
+            throw DCException(getExceptionString("readDataSetMeta", "Entry not found by name", name));
 
         Dimensions src_size(dataset.getSize() - srcOffset);
         dataset.read(dstBuffer, dstOffset, src_size, srcOffset, sizeRead, srcDims, NULL);

--- a/src/ParallelDataCollector.cpp
+++ b/src/ParallelDataCollector.cpp
@@ -310,17 +310,17 @@ namespace splash
             *count = param.count;
     }
 
-    DCAttributeInfo* ParallelDataCollector::readGlobalAttributeMeta(
+    AttributeInfo* ParallelDataCollector::readGlobalAttributeInfo(
             int32_t id,
             const char* name,
             Dimensions */*mpiPosition*/)
     throw (DCException)
     {
         if (name == NULL)
-            throw DCException(getExceptionString("readGlobalAttributeMeta", "a parameter was null"));
+            throw DCException(getExceptionString("readGlobalAttributeInfo", "a parameter was null"));
 
         if (fileStatus == FST_CLOSED || fileStatus == FST_CREATING)
-            throw DCException(getExceptionString("readGlobalAttributeMeta", "this access is not permitted"));
+            throw DCException(getExceptionString("readGlobalAttributeInfo", "this access is not permitted"));
 
         DCParallelGroup group_custom;
         group_custom.open(handles.get(id), PDC_GROUP_CUSTOM);
@@ -431,7 +431,7 @@ namespace splash
             return -1;
     }
 
-    DCAttributeInfo* ParallelDataCollector::readAttributeMeta(int32_t id,
+    AttributeInfo* ParallelDataCollector::readAttributeInfo(int32_t id,
             const char *dataName,
             const char *attrName,
             Dimensions* /*mpiPosition*/)
@@ -439,10 +439,10 @@ namespace splash
     {
         // mpiPosition is ignored
         if (attrName == NULL)
-            throw DCException(getExceptionString("readAttributeMeta", "a parameter was null"));
+            throw DCException(getExceptionString("readAttributeInfo", "a parameter was null"));
 
         if (strlen(attrName) == 0)
-            throw DCException(getExceptionString("readAttributeMeta", "empty attribute name"));
+            throw DCException(getExceptionString("readAttributeInfo", "empty attribute name"));
 
         DCParallelGroup group;
         H5ObjectId objId(openGroup(group, id, dataName));

--- a/src/ParallelDataCollector.cpp
+++ b/src/ParallelDataCollector.cpp
@@ -29,6 +29,7 @@
 
 #include "splash/version.hpp"
 #include "splash/ParallelDataCollector.hpp"
+#include "splash/AttributeInfo.hpp"
 #include "splash/basetypes/basetypes.hpp"
 #include "splash/core/DCParallelDataSet.hpp"
 #include "splash/core/DCAttribute.hpp"
@@ -310,7 +311,7 @@ namespace splash
             *count = param.count;
     }
 
-    AttributeInfo* ParallelDataCollector::readGlobalAttributeInfo(
+    AttributeInfo ParallelDataCollector::readGlobalAttributeInfo(
             int32_t id,
             const char* name,
             Dimensions* /*mpiPosition*/)
@@ -431,7 +432,7 @@ namespace splash
             return -1;
     }
 
-    AttributeInfo* ParallelDataCollector::readAttributeInfo(int32_t id,
+    AttributeInfo ParallelDataCollector::readAttributeInfo(int32_t id,
             const char *dataName,
             const char *attrName,
             Dimensions* /*mpiPosition*/)

--- a/src/ParallelDataCollector.cpp
+++ b/src/ParallelDataCollector.cpp
@@ -313,7 +313,7 @@ namespace splash
     AttributeInfo* ParallelDataCollector::readGlobalAttributeInfo(
             int32_t id,
             const char* name,
-            Dimensions */*mpiPosition*/)
+            Dimensions* /*mpiPosition*/)
     throw (DCException)
     {
         if (name == NULL)
@@ -1212,9 +1212,9 @@ namespace splash
     }
 
     void ParallelDataCollector::createReference(int32_t /*srcID*/,
-            const char */*srcName*/,
+            const char* /*srcName*/,
             int32_t /*dstID*/,
-            const char */*dstName*/,
+            const char* /*dstName*/,
             Dimensions /*count*/,
             Dimensions /*offset*/,
             Dimensions /*stride*/)

--- a/src/ParallelDomainCollector.cpp
+++ b/src/ParallelDomainCollector.cpp
@@ -23,6 +23,7 @@
 #include "splash/basetypes/basetypes.hpp"
 
 #include "splash/ParallelDomainCollector.hpp"
+#include "splash/AttributeInfo.hpp"
 #include "splash/core/DCParallelDataSet.hpp"
 #include "splash/core/logging.hpp"
 

--- a/src/ParallelDomainCollector.cpp
+++ b/src/ParallelDomainCollector.cpp
@@ -79,8 +79,8 @@ namespace splash
 
         Domain domain;
 
-        readAttribute(id, name, DOMCOL_ATTR_GLOBAL_SIZE, domain.getSize().getPointer());
-        readAttribute(id, name, DOMCOL_ATTR_GLOBAL_OFFSET, domain.getOffset().getPointer());
+        readAttributeInfo(id, name, DOMCOL_ATTR_GLOBAL_SIZE).read(domain.getSize().getPointer(), domain.getSize().getSize());
+        readAttributeInfo(id, name, DOMCOL_ATTR_GLOBAL_OFFSET).read(domain.getOffset().getPointer(), domain.getOffset().getSize());
 
         return domain;
     }
@@ -95,8 +95,8 @@ namespace splash
 
         Domain domain;
 
-        readAttribute(id, name, DOMCOL_ATTR_SIZE, domain.getSize().getPointer());
-        readAttribute(id, name, DOMCOL_ATTR_OFFSET, domain.getOffset().getPointer());
+        readAttributeInfo(id, name, DOMCOL_ATTR_SIZE).read(domain.getSize().getPointer(), domain.getSize().getSize());
+        readAttributeInfo(id, name, DOMCOL_ATTR_OFFSET).read(domain.getOffset().getPointer(), domain.getOffset().getSize());
 
         return domain;
     }
@@ -110,12 +110,8 @@ namespace splash
             bool lazyLoad)
     throw (DCException)
     {
-        Domain local_client_domain, global_client_domain;
-
-        readAttribute(id, name, DOMCOL_ATTR_OFFSET, local_client_domain.getOffset().getPointer());
-        readAttribute(id, name, DOMCOL_ATTR_SIZE, local_client_domain.getSize().getPointer());
-        readAttribute(id, name, DOMCOL_ATTR_GLOBAL_OFFSET, global_client_domain.getOffset().getPointer());
-        readAttribute(id, name, DOMCOL_ATTR_GLOBAL_SIZE, global_client_domain.getSize().getPointer());
+        Domain local_client_domain = getLocalDomain(id, name);
+        Domain global_client_domain = getGlobalDomain(id, name);
 
         Domain client_domain(
                 local_client_domain.getOffset() + global_client_domain.getOffset(),
@@ -125,7 +121,7 @@ namespace splash
         read(id, name, data_elements, NULL);
 
         DomDataClass tmp_data_class = UndefinedType;
-        readAttribute(id, name, DOMCOL_ATTR_CLASS, &tmp_data_class);
+        readAttributeInfo(id, name, DOMCOL_ATTR_CLASS).read(&tmp_data_class, sizeof(tmp_data_class));
 
         if (tmp_data_class == GridType && data_elements != client_domain.getSize())
             throw DCException(getExceptionString("readDomainDataForRank",

--- a/src/SerialDataCollector.cpp
+++ b/src/SerialDataCollector.cpp
@@ -29,6 +29,7 @@
 #include <sys/stat.h>
 
 #include "splash/SerialDataCollector.hpp"
+#include "splash/AttributeInfo.hpp"
 #include "splash/core/DCAttribute.hpp"
 #include "splash/core/DCDataSet.hpp"
 #include "splash/core/DCGroup.hpp"
@@ -267,7 +268,7 @@ namespace splash
             return -1;
     }
 
-    AttributeInfo* SerialDataCollector::readGlobalAttributeInfo(
+    AttributeInfo SerialDataCollector::readGlobalAttributeInfo(
             int32_t /*id*/,
             const char* name,
             Dimensions *mpiPosition)
@@ -343,7 +344,7 @@ namespace splash
         }
     }
 
-    AttributeInfo* SerialDataCollector::readAttributeInfo(int32_t id,
+    AttributeInfo SerialDataCollector::readAttributeInfo(int32_t id,
             const char *dataName,
             const char *attrName,
             Dimensions *mpiPosition)

--- a/src/SerialDataCollector.cpp
+++ b/src/SerialDataCollector.cpp
@@ -385,10 +385,10 @@ namespace splash
         H5ObjectId objId(openGroup(group, id, dataName, mpiPosition));
 
         // When no object is returned read attribute from the iteration group
-        if (!objId)
-            DCAttribute::readAttribute(attrName, group.getHandle(), data);
-        else
+        if (objId)
             DCAttribute::readAttribute(attrName, objId, data);
+        else
+            DCAttribute::readAttribute(attrName, group.getHandle(), data);
     }
 
     void SerialDataCollector::writeAttribute(int32_t id,

--- a/src/SerialDataCollector.cpp
+++ b/src/SerialDataCollector.cpp
@@ -267,7 +267,7 @@ namespace splash
             return -1;
     }
 
-    DCAttributeInfo* SerialDataCollector::readGlobalAttributeMeta(
+    AttributeInfo* SerialDataCollector::readGlobalAttributeInfo(
             int32_t /*id*/,
             const char* name,
             Dimensions *mpiPosition)
@@ -275,7 +275,7 @@ namespace splash
     {
         // mpiPosition is allowed to be NULL here
         if (name == NULL)
-            throw DCException(getExceptionString("readGlobalAttributeMeta", "a parameter was null"));
+            throw DCException(getExceptionString("readGlobalAttributeInfo", "a parameter was null"));
 
         DCGroup group_custom;
         openCustomGroup(group_custom, mpiPosition);
@@ -343,7 +343,7 @@ namespace splash
         }
     }
 
-    DCAttributeInfo* SerialDataCollector::readAttributeMeta(int32_t id,
+    AttributeInfo* SerialDataCollector::readAttributeInfo(int32_t id,
             const char *dataName,
             const char *attrName,
             Dimensions *mpiPosition)
@@ -351,10 +351,10 @@ namespace splash
     {
         // mpiPosition is allowed to be NULL here
         if (attrName == NULL)
-            throw DCException(getExceptionString("readAttributeMeta", "a parameter was null"));
+            throw DCException(getExceptionString("readAttributeInfo", "a parameter was null"));
 
         if (strlen(attrName) == 0)
-            throw DCException(getExceptionString("readAttributeMeta", "empty attribute name"));
+            throw DCException(getExceptionString("readAttributeInfo", "empty attribute name"));
 
         DCGroup group;
         H5ObjectId objId(openGroup(group, id, dataName, mpiPosition));

--- a/src/SerialDataCollector.cpp
+++ b/src/SerialDataCollector.cpp
@@ -29,14 +29,12 @@
 #include <sys/stat.h>
 
 #include "splash/SerialDataCollector.hpp"
-
-#include "splash/basetypes/basetypes.hpp"
-
 #include "splash/core/DCAttribute.hpp"
 #include "splash/core/DCDataSet.hpp"
 #include "splash/core/DCGroup.hpp"
 #include "splash/core/SDCHelper.hpp"
 #include "splash/core/logging.hpp"
+#include "splash/core/H5IdWrapper.hpp"
 #include "splash/basetypes/basetypes.hpp"
 
 namespace splash
@@ -199,18 +197,13 @@ namespace splash
         fileStatus = FST_CLOSED;
     }
 
-    void SerialDataCollector::readGlobalAttribute(
-            const char* name,
-            void* data,
-            Dimensions *mpiPosition)
-    throw (DCException)
+    void SerialDataCollector::openCustomGroup(DCGroup& group,
+                    Dimensions *mpiPosition) throw (DCException)
     {
-        // mpiPosition is allowed to be NULL here
-        if (name == NULL || data == NULL)
-            throw DCException(getExceptionString("readGlobalAttribute", "a parameter was null"));
+        // Note: Factored out from readGlobalAttribute
 
         if (fileStatus == FST_CLOSED || fileStatus == FST_CREATING)
-            throw DCException(getExceptionString("readGlobalAttribute", "this access is not permitted"));
+            throw DCException(getExceptionString("openCustomGroup", "this access is not permitted"));
 
         std::stringstream group_custom_name;
         if (mpiPosition == NULL || fileStatus == FST_MERGING)
@@ -231,8 +224,77 @@ namespace splash
             mpi_rank = mpi_pos[2] * mpiTopology[0] * mpiTopology[1] + mpi_pos[1] * mpiTopology[0] + mpi_pos[0];
         }
 
+        group.open(handles.get(mpi_rank), custom_string.c_str());
+    }
+
+    hid_t SerialDataCollector::openGroup(DCGroup& group, int32_t id, const char* dataName,
+            Dimensions *mpiPosition) throw (DCException)
+    {
+        // Note: Factored out from readAttribute
+
+        // dataName may be NULL, attribute is read to iteration group in that case
+        if (dataName && strlen(dataName) == 0)
+            throw DCException(getExceptionString("openGroup", "empty dataset name"));
+
+        if (fileStatus == FST_CLOSED || fileStatus == FST_CREATING)
+            throw DCException(getExceptionString("openGroup", "this access is not permitted"));
+
+        std::string group_path, obj_name;
+        std::string dataNameInternal = "";
+        if (dataName)
+            dataNameInternal.assign(dataName);
+        DCDataSet::getFullDataPath(dataNameInternal, SDC_GROUP_DATA, id, group_path, obj_name);
+
+        Dimensions mpi_pos(0, 0, 0);
+        if ((fileStatus == FST_MERGING) && (mpiPosition != NULL))
+        {
+            mpi_pos.set(*mpiPosition);
+        }
+
+        group.open(handles.get(mpi_pos), group_path);
+
+        if (dataName)
+        {
+            // read from the dataset or group
+            if (H5Lexists(group.getHandle(), obj_name.c_str(), H5P_LINK_ACCESS_DEFAULT))
+                return H5Oopen(group.getHandle(), obj_name.c_str(), H5P_DEFAULT);
+            else
+            {
+                throw DCException(getExceptionString("openGroup",
+                        "dataset not found", obj_name.c_str()));
+            }
+        } else
+            return -1;
+    }
+
+    DCAttributeInfo* SerialDataCollector::readGlobalAttributeMeta(
+            int32_t /*id*/,
+            const char* name,
+            Dimensions *mpiPosition)
+    throw (DCException)
+    {
+        // mpiPosition is allowed to be NULL here
+        if (name == NULL)
+            throw DCException(getExceptionString("readGlobalAttributeMeta", "a parameter was null"));
+
         DCGroup group_custom;
-        group_custom.open(handles.get(mpi_rank), custom_string.c_str());
+        openCustomGroup(group_custom, mpiPosition);
+
+        return DCAttribute::readAttributeInfo(name, group_custom.getHandle());
+    }
+
+    void SerialDataCollector::readGlobalAttribute(
+            const char* name,
+            void* data,
+            Dimensions *mpiPosition)
+    throw (DCException)
+    {
+        // mpiPosition is allowed to be NULL here
+        if (name == NULL || data == NULL)
+            throw DCException(getExceptionString("readGlobalAttribute", "a parameter was null"));
+
+        DCGroup group_custom;
+        openCustomGroup(group_custom, mpiPosition);
 
         try
         {
@@ -281,6 +343,29 @@ namespace splash
         }
     }
 
+    DCAttributeInfo* SerialDataCollector::readAttributeMeta(int32_t id,
+            const char *dataName,
+            const char *attrName,
+            Dimensions *mpiPosition)
+    throw (DCException)
+    {
+        // mpiPosition is allowed to be NULL here
+        if (attrName == NULL)
+            throw DCException(getExceptionString("readAttributeMeta", "a parameter was null"));
+
+        if (strlen(attrName) == 0)
+            throw DCException(getExceptionString("readAttributeMeta", "empty attribute name"));
+
+        DCGroup group;
+        H5ObjectId objId(openGroup(group, id, dataName, mpiPosition));
+
+        // When no object is returned read attribute from the iteration group
+        if (!objId)
+            return DCAttribute::readAttributeInfo(attrName, group.getHandle());
+        else
+            return DCAttribute::readAttributeInfo(attrName, objId);
+    }
+
     void SerialDataCollector::readAttribute(int32_t id,
             const char *dataName,
             const char *attrName,
@@ -292,57 +377,17 @@ namespace splash
         if (attrName == NULL || data == NULL)
             throw DCException(getExceptionString("readAttribute", "a parameter was null"));
 
-        // dataName may be NULL, attribute is read to iteration group in that case
-        if (dataName && strlen(dataName) == 0)
-            throw DCException(getExceptionString("readAttribute", "empty dataset name"));
-
         if (strlen(attrName) == 0)
             throw DCException(getExceptionString("readAttribute", "empty attribute name"));
 
-        if (fileStatus == FST_CLOSED || fileStatus == FST_CREATING)
-            throw DCException(getExceptionString("readAttribute", "this access is not permitted"));
-
-        std::string group_path, obj_name;
-        std::string dataNameInternal = "";
-        if (dataName)
-            dataNameInternal.assign(dataName);
-        DCDataSet::getFullDataPath(dataNameInternal, SDC_GROUP_DATA, id, group_path, obj_name);
-
-        Dimensions mpi_pos(0, 0, 0);
-        if ((fileStatus == FST_MERGING) && (mpiPosition != NULL))
-        {
-            mpi_pos.set(*mpiPosition);
-        }
-
         DCGroup group;
-        group.open(handles.get(mpi_pos), group_path);
+        H5ObjectId objId(openGroup(group, id, dataName, mpiPosition));
 
-        if (dataName)
-        {
-            // read attribute from the dataset or group
-            hid_t obj_id = -1;
-            if (H5Lexists(group.getHandle(), obj_name.c_str(), H5P_LINK_ACCESS_DEFAULT))
-            {
-                obj_id = H5Oopen(group.getHandle(), obj_name.c_str(), H5P_DEFAULT);
-                try
-                {
-                    DCAttribute::readAttribute(attrName, obj_id, data);
-                } catch (const DCException&)
-                {
-                    H5Oclose(obj_id);
-                    throw;
-                }
-                H5Oclose(obj_id);
-            } else
-            {
-                throw DCException(getExceptionString("readAttribute",
-                        "dataset not found", obj_name.c_str()));
-            }
-        } else
-        {
-            // read attribute from the iteration group
+        // When no object is returned read attribute from the iteration group
+        if (!objId)
             DCAttribute::readAttribute(attrName, group.getHandle(), data);
-        }
+        else
+            DCAttribute::readAttribute(attrName, objId, data);
     }
 
     void SerialDataCollector::writeAttribute(int32_t id,

--- a/src/include/splash/AttributeInfo.hpp
+++ b/src/include/splash/AttributeInfo.hpp
@@ -47,13 +47,13 @@ namespace splash
      * delete info;
      * \endcode
      */
-    class DCAttributeInfo
+    class AttributeInfo
     {
         H5AttributeId attr_;
 
    public:
-        explicit DCAttributeInfo(hid_t attr);
-        ~DCAttributeInfo();
+        explicit AttributeInfo(hid_t attr);
+        ~AttributeInfo();
 
         /** Return the size of the required memory in bytes when querying the value */
         size_t getMemSize() throw(DCException);
@@ -107,8 +107,8 @@ namespace splash
         void read(void* buf, size_t bufSize) throw(DCException);
     private:
         // Don't copy
-        DCAttributeInfo(const DCAttributeInfo&);
-        DCAttributeInfo& operator=(const DCAttributeInfo&);
+        AttributeInfo(const AttributeInfo&);
+        AttributeInfo& operator=(const AttributeInfo&);
 
         std::string getExceptionString(const std::string& msg);
         void loadType() throw(DCException);

--- a/src/include/splash/AttributeInfo.hpp
+++ b/src/include/splash/AttributeInfo.hpp
@@ -26,6 +26,7 @@
 #include "splash/Dimensions.hpp"
 #include "splash/DCException.hpp"
 #include "splash/core/H5IdWrapper.hpp"
+#include "splash/core/splashMacros.hpp"
 #include <string>
 
 namespace splash
@@ -99,11 +100,10 @@ namespace splash
          * No data conversion occurs, so the type as found in the file is used.
          * Throws an exception if the attribute could not be read or the buffer is to small.
          *
-         * Deprecated!
-         *
          * @param buf     Pointer to buffer
          * @param bufSize Size of the buffer
          */
+        SPLASH_DEPRECATED("Pass CollectionType")
         void read(void* buf, size_t bufSize) throw(DCException);
     private:
         // Don't copy

--- a/src/include/splash/AttributeInfo.hpp
+++ b/src/include/splash/AttributeInfo.hpp
@@ -103,11 +103,13 @@ namespace splash
          * Read the data of this attribute into the buffer of the given size.
          * No data conversion occurs, so the type as found in the file is used.
          * Throws an exception if the attribute could not be read or the buffer is to small.
+         * Warning: Might be unsafe if you are not the author of the HDF5 file or the data type
+         *          differs from the expected one. Check the meta-data and/or pass the
+         *          CollectionType to make sure you get what you expect.
          *
          * @param buf     Pointer to buffer
          * @param bufSize Size of the buffer
          */
-        SPLASH_DEPRECATED("Pass CollectionType")
         void read(void* buf, size_t bufSize) throw(DCException);
     private:
 

--- a/src/include/splash/AttributeInfo.hpp
+++ b/src/include/splash/AttributeInfo.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016 Alexander Grund
  *
  * This file is part of libSplash.
@@ -49,7 +49,7 @@ namespace splash
      */
     class AttributeInfo
     {
-        H5AttributeId attr_;
+        H5AttributeIdRefCt attr_;
 
    public:
         explicit AttributeInfo(hid_t attr);
@@ -111,17 +111,15 @@ namespace splash
          * @param bufSize Size of the buffer
          */
         void read(void* buf, size_t bufSize) throw(DCException);
+
+        friend void swap(AttributeInfo& lhs, AttributeInfo& rhs);
+
     private:
 
         std::string getExceptionString(const std::string& msg);
         void loadType() throw(DCException);
         void loadSpace() throw(DCException);
         
-        /** Reference counter for the attribute */
-        unsigned* refCt_;
-        /** Decreases the ref counter by 1 and releases the attribute or the ref counter */
-        void releaseReference();
-
         // Those values are lazy loaded on access
         CollectionType* colType_;
         H5TypeId type_;

--- a/src/include/splash/AttributeInfo.hpp
+++ b/src/include/splash/AttributeInfo.hpp
@@ -111,6 +111,13 @@ namespace splash
          * @param bufSize Size of the buffer
          */
         void read(void* buf, size_t bufSize) throw(DCException);
+        
+        /**
+         * Closes the attribute invalidating all future calls to this object
+         * Note: If there are multiple instances relating to the same HDF5-Attribute
+         * all of them must be closed or destroyed
+         */
+        void close();
 
         friend void swap(AttributeInfo& lhs, AttributeInfo& rhs);
 

--- a/src/include/splash/AttributeInfo.hpp
+++ b/src/include/splash/AttributeInfo.hpp
@@ -38,14 +38,13 @@ namespace splash
      *
      * Usage example:
      * \code{.cpp}
-     * AttributeInfo* info = dc.readAttribute(iterationId, "groupName", "attrName");
+     * AttributeInfo info = dc.readAttribute(iterationId, "groupName", "attrName");
      * // Check that extents are as expected
-     * if(!info->isScalar()) throw error(...);
+     * if(!info.isScalar()) throw error(...);
      * // Optionally further checks
      * ...
      * int result;
-     * info->read(ColTypeInt(), &result);
-     * delete info;
+     * info.read(ColTypeInt(), &result);
      * \endcode
      */
     class AttributeInfo
@@ -54,7 +53,12 @@ namespace splash
 
    public:
         explicit AttributeInfo(hid_t attr);
+        /** Construct from an attribute id, takes over ownership! */
+        explicit AttributeInfo(H5AttributeId& attr);
         ~AttributeInfo();
+
+        AttributeInfo(const AttributeInfo& other);
+        AttributeInfo& operator=(const AttributeInfo& other);
 
         /** Return the size of the required memory in bytes when querying the value */
         size_t getMemSize() throw(DCException);
@@ -106,13 +110,15 @@ namespace splash
         SPLASH_DEPRECATED("Pass CollectionType")
         void read(void* buf, size_t bufSize) throw(DCException);
     private:
-        // Don't copy
-        AttributeInfo(const AttributeInfo&);
-        AttributeInfo& operator=(const AttributeInfo&);
 
         std::string getExceptionString(const std::string& msg);
         void loadType() throw(DCException);
         void loadSpace() throw(DCException);
+        
+        /** Reference counter for the attribute */
+        unsigned* refCt_;
+        /** Decreases the ref counter by 1 and releases the attribute or the ref counter */
+        void releaseReference();
 
         // Those values are lazy loaded on access
         CollectionType* colType_;

--- a/src/include/splash/DCAttributeInfo.hpp
+++ b/src/include/splash/DCAttributeInfo.hpp
@@ -38,6 +38,7 @@ namespace splash
         CollectionType* colType_;
         Dimensions dims_;
         uint32_t ndims_;
+        bool isVarSize_;
 
         friend class DCAttribute;
         // Don't copy
@@ -57,6 +58,9 @@ namespace splash
         uint32_t getNDims() const { return ndims_; }
         /** Return whether this is a scalar value */
         bool isScalar() const { return ndims_ == 1 && dims_.getScalarSize() == 1; }
+        /** Return true, if the attribute has a variable size in which case reading
+         *  it will only return its pointer */
+        bool isVarSize() const { return isVarSize_; }
     };
 }
 

--- a/src/include/splash/DCAttributeInfo.hpp
+++ b/src/include/splash/DCAttributeInfo.hpp
@@ -34,13 +34,25 @@ namespace splash
 
     /**
      * Class holding information about an attribute.
+     *
+     * Usage example:
+     * \code{.cpp}
+     * AttributeInfo* info = dc.readAttribute(iterationId, "groupName", "attrName");
+     * // Check that extents are as expected
+     * if(!info->isScalar()) throw error(...);
+     * // Optionally further checks
+     * ...
+     * int result;
+     * info->read(ColTypeInt(), &result);
+     * delete info;
+     * \endcode
      */
     class DCAttributeInfo
     {
         H5AttributeId attr_;
 
    public:
-        DCAttributeInfo(hid_t attr);
+        explicit DCAttributeInfo(hid_t attr);
         ~DCAttributeInfo();
 
         /** Return the size of the required memory in bytes when querying the value */
@@ -61,7 +73,8 @@ namespace splash
 
         /**
          * Read the data of this attribute into the buffer of the given type.
-         * Data conversion may occur, if required. See the HDF5 manual for details
+         * Data conversion may occur, if required.
+         * See the HDF5 manual for details (6.10. Data Transfer: Datatype Conversion and Selection)
          * Throws an exception if the attribute could not be read or converted
          *
          * @param colType Type of the buffer
@@ -71,7 +84,8 @@ namespace splash
 
         /**
          * Read the data of this attribute into the buffer of the given type.
-         * Data conversion may occur, if required. See the HDF5 manual for details
+         * Data conversion may occur, if required.
+         * See the HDF5 manual for details (6.10. Data Transfer: Datatype Conversion and Selection)
          * Does not throw exception, so it can be used for trying different types
          *
          * @param colType Type of the buffer
@@ -84,6 +98,8 @@ namespace splash
          * Read the data of this attribute into the buffer of the given size.
          * No data conversion occurs, so the type as found in the file is used.
          * Throws an exception if the attribute could not be read or the buffer is to small.
+         *
+         * Deprecated!
          *
          * @param buf     Pointer to buffer
          * @param bufSize Size of the buffer

--- a/src/include/splash/DCAttributeInfo.hpp
+++ b/src/include/splash/DCAttributeInfo.hpp
@@ -1,0 +1,63 @@
+/**
+ * Copyright 2016 Alexander Grund
+ *
+ * This file is part of libSplash.
+ *
+ * libSplash is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * libSplash is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libSplash.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef DCATTRIBUTE_INFO_H
+#define DCATTRIBUTE_INFO_H
+
+#include "splash/Dimensions.hpp"
+
+namespace splash
+{
+    class CollectionType;
+
+    /**
+     * Class holding information about an attribute.
+     */
+    class DCAttributeInfo
+    {
+        size_t memSize_;
+        CollectionType* colType_;
+        Dimensions dims_;
+        uint32_t ndims_;
+
+        friend class DCAttribute;
+        // Don't copy
+        DCAttributeInfo(const DCAttributeInfo&);
+        DCAttributeInfo& operator=(const DCAttributeInfo&);
+    public:
+        DCAttributeInfo();
+        ~DCAttributeInfo();
+
+        /** Return the size of the required memory in bytes when querying the value */
+        size_t getMemSize() const { return memSize_; }
+        /** Return the CollectionType. Might be ColTypeUnknown */
+        const CollectionType& getType() const { return *colType_; }
+        /** Return the size in each dimension */
+        const Dimensions& getDims() const { return dims_; }
+        /** Return the number of dimensions */
+        uint32_t getNDims() const { return ndims_; }
+        /** Return whether this is a scalar value */
+        bool isScalar() const { return ndims_ == 1 && dims_.getScalarSize() == 1; }
+    };
+}
+
+#endif /* DCATTRIBUTE_INFO_H */

--- a/src/include/splash/DCAttributeInfo.hpp
+++ b/src/include/splash/DCAttributeInfo.hpp
@@ -24,6 +24,7 @@
 #define DCATTRIBUTE_INFO_H
 
 #include "splash/Dimensions.hpp"
+#include "splash/core/H5IdWrapper.hpp"
 
 namespace splash
 {
@@ -34,34 +35,39 @@ namespace splash
      */
     class DCAttributeInfo
     {
-        size_t memSize_;
-        CollectionType* colType_;
-        Dimensions dims_;
-        uint32_t ndims_;
-        bool isVarSize_;
+        H5AttributeId attr_;
 
-        friend class DCAttribute;
-        // Don't copy
-        DCAttributeInfo(const DCAttributeInfo&);
-        DCAttributeInfo& operator=(const DCAttributeInfo&);
-    public:
-        DCAttributeInfo();
+   public:
+        DCAttributeInfo(hid_t attr);
         ~DCAttributeInfo();
 
         /** Return the size of the required memory in bytes when querying the value */
-        size_t getMemSize() const { return memSize_; }
+        size_t getMemSize();
         /** Return the CollectionType. Might be ColTypeUnknown */
-        const CollectionType& getType() const { return *colType_; }
+        const CollectionType& getType();
         /** Return the size in each dimension */
-        const Dimensions& getDims() const { return dims_; }
+        Dimensions getDims();
         /** Return the number of dimensions */
-        uint32_t getNDims() const { return ndims_; }
+        uint32_t getNDims();
         /** Return whether this is a scalar value */
-        bool isScalar() const { return ndims_ == 1 && dims_.getScalarSize() == 1; }
+        bool isScalar() { return getNDims() == 1 && getDims().getScalarSize() == 1; }
         /** Return true, if the attribute has a variable size in which case reading
          *  it will only return its pointer */
-        bool isVarSize() const { return isVarSize_; }
-    };
+        bool isVarSize();
+
+    private:
+        // Don't copy
+        DCAttributeInfo(const DCAttributeInfo&);
+        DCAttributeInfo& operator=(const DCAttributeInfo&);
+        void loadType();
+        void loadSpace();
+
+        // Those values are lazy loaded on access
+        CollectionType* colType_;
+        H5TypeId type_;
+        H5DataspaceId space_;
+        uint32_t nDims_;
+};
 }
 
 #endif /* DCATTRIBUTE_INFO_H */

--- a/src/include/splash/DCException.hpp
+++ b/src/include/splash/DCException.hpp
@@ -32,7 +32,7 @@ namespace splash
      *
      * All calls to DataCollector should handle these exceptions.
      */
-    class DCException : virtual public std::runtime_error
+    class DCException : public std::runtime_error
     {
     public:
 

--- a/src/include/splash/DataCollector.hpp
+++ b/src/include/splash/DataCollector.hpp
@@ -56,7 +56,7 @@
 namespace splash
 {
 
-    class DCAttributeInfo;
+    class AttributeInfo;
 
     class DataCollector
     {
@@ -315,7 +315,7 @@ namespace splash
          * @return Pointer to heap allocated DCAttributeInfo instance or NULL if not found.
          *         Must be freed by the caller.
          */
-        virtual DCAttributeInfo* readGlobalAttributeMeta(
+        virtual AttributeInfo* readGlobalAttributeInfo(
                 int32_t id,
                 const char *name,
                 Dimensions *mpiPosition = NULL) = 0;
@@ -374,7 +374,7 @@ namespace splash
          * @return Pointer to heap allocated DCAttributeInfo instance or NULL if not found.
          *         Must be freed by the caller.
          */
-        virtual DCAttributeInfo* readAttributeMeta(int32_t id,
+        virtual AttributeInfo* readAttributeInfo(int32_t id,
                 const char *dataName,
                 const char *attrName,
                 Dimensions *mpiPosition = NULL) = 0;

--- a/src/include/splash/DataCollector.hpp
+++ b/src/include/splash/DataCollector.hpp
@@ -316,7 +316,7 @@ namespace splash
          * @return Pointer to heap allocated DCAttributeInfo instance or NULL if not found.
          *         Must be freed by the caller.
          */
-        virtual AttributeInfo* readGlobalAttributeInfo(
+        virtual AttributeInfo readGlobalAttributeInfo(
                 int32_t id,
                 const char *name,
                 Dimensions *mpiPosition = NULL) = 0;
@@ -376,7 +376,7 @@ namespace splash
          * @return Pointer to heap allocated DCAttributeInfo instance or NULL if not found.
          *         Must be freed by the caller.
          */
-        virtual AttributeInfo* readAttributeInfo(int32_t id,
+        virtual AttributeInfo readAttributeInfo(int32_t id,
                 const char *dataName,
                 const char *attrName,
                 Dimensions *mpiPosition = NULL) = 0;

--- a/src/include/splash/DataCollector.hpp
+++ b/src/include/splash/DataCollector.hpp
@@ -51,13 +51,12 @@
 #include "splash/CollectionType.hpp"
 #include "splash/Dimensions.hpp"
 #include "splash/Selection.hpp"
+#include "splash/AttributeInfo.hpp"
 #include "splash/core/DCDataSet.hpp"
 #include "splash/core/splashMacros.hpp"
 
 namespace splash
 {
-
-    class AttributeInfo;
 
     class DataCollector
     {

--- a/src/include/splash/DataCollector.hpp
+++ b/src/include/splash/DataCollector.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015 Felix Schmitt, Axel Huebl
+ * Copyright 2013-2016 Felix Schmitt, Axel Huebl, Alexander Grund
  *
  * This file is part of libSplash.
  *
@@ -55,6 +55,8 @@
 
 namespace splash
 {
+
+    class DCAttributeInfo;
 
     class DataCollector
     {
@@ -302,6 +304,23 @@ namespace splash
                 Dimensions stride) = 0;
 
         /**
+         * Reads global attribute meta information from HDF5 file.
+         *
+         * @param id ID for iteration.
+         * @param name Name for the attribute.
+         * @param mpiPosition Pointer to Dimensions class.
+         * Identifies MPI-position-specific custom group.
+         * Use NULL to read from default group.
+         *
+         * @return Pointer to heap allocated DCAttributeInfo instance or NULL if not found.
+         *         Must be freed by the caller.
+         */
+        virtual DCAttributeInfo* readGlobalAttributeMeta(
+                int32_t id,
+                const char *name,
+                Dimensions *mpiPosition = NULL) = 0;
+
+        /**
          * Reads global attribute from HDF5 file.
          *
          * @param name Name for the attribute.
@@ -340,6 +359,25 @@ namespace splash
                 uint32_t ndims,
                 const Dimensions dims,
                 const void* buf) = 0;
+
+        /**
+         * Reads attribute meta data from a single dataset.
+         *
+         * @param id ID for iteration.
+         * @param dataName Name of the dataset in group \p id to read attribute from.
+         * If dataName is NULL, the attribute is read from the iteration group.
+         * @param attrName Name of the attribute.
+         * @param mpiPosition Pointer to Dimensions class.
+         * Identifies MPI-position-specific file while in FAT_READ_MERGED mode.
+         * Use NULL to read from default file index.
+         *
+         * @return Pointer to heap allocated DCAttributeInfo instance or NULL if not found.
+         *         Must be freed by the caller.
+         */
+        virtual DCAttributeInfo* readAttributeMeta(int32_t id,
+                const char *dataName,
+                const char *attrName,
+                Dimensions *mpiPosition = NULL) = 0;
 
         /**
          * Reads an attribute from a single dataset.

--- a/src/include/splash/DataCollector.hpp
+++ b/src/include/splash/DataCollector.hpp
@@ -52,6 +52,7 @@
 #include "splash/Dimensions.hpp"
 #include "splash/Selection.hpp"
 #include "splash/core/DCDataSet.hpp"
+#include "splash/core/splashMacros.hpp"
 
 namespace splash
 {
@@ -329,6 +330,7 @@ namespace splash
          * Identifies MPI-position-specific custom group.
          * Use NULL to read from default group.
          */
+        SPLASH_DEPRECATED("Use safer readGlobalAttributeInfo")
         virtual void readGlobalAttribute(
                 const char *name,
                 void* buf,
@@ -391,6 +393,7 @@ namespace splash
          * Identifies MPI-position-specific file while in FAT_READ_MERGED mode.
          * Use NULL to read from default file index.
          */
+        SPLASH_DEPRECATED("Use safer readAttributeInfo")
         virtual void readAttribute(int32_t id,
                 const char *dataName,
                 const char *attrName,

--- a/src/include/splash/IParallelDataCollector.hpp
+++ b/src/include/splash/IParallelDataCollector.hpp
@@ -110,6 +110,7 @@ namespace splash
          * @param name Name of the attribute.
          * @param buf Destination buffer for attribute.
          */
+        SPLASH_DEPRECATED("Use safer readGlobalAttributeInfo")
         virtual void readGlobalAttribute(int32_t id,
                 const char* name,
                 void* buf) = 0;
@@ -134,7 +135,8 @@ namespace splash
                 const Dimensions dims,
                 const void* buf) = 0;
 
-        virtual void readGlobalAttribute(const char *name,
+       SPLASH_DEPRECATED("Use safer readGlobalAttributeInfo")
+       virtual void readGlobalAttribute(const char *name,
                 void* buf,
                 Dimensions *mpiPosition = NULL) = 0;
 

--- a/src/include/splash/ParallelDataCollector.hpp
+++ b/src/include/splash/ParallelDataCollector.hpp
@@ -259,7 +259,7 @@ namespace splash
                 int32_t dstID,
                 const char *dstName) throw (DCException);
 
-        AttributeInfo* readGlobalAttributeInfo(int32_t id,
+        AttributeInfo readGlobalAttributeInfo(int32_t id,
                 const char* name,
                 Dimensions *mpiPosition = NULL) throw (DCException);
 
@@ -280,8 +280,7 @@ namespace splash
                 const Dimensions dims,
                 const void* buf) throw (DCException);
 
-        SPLASH_DEPRECATED("Use safer readAttributeInfo")
-        AttributeInfo* readAttributeInfo(int32_t id,
+        AttributeInfo readAttributeInfo(int32_t id,
                 const char *dataName,
                 const char *attrName,
                 Dimensions *mpiPosition = NULL) throw (DCException);

--- a/src/include/splash/ParallelDataCollector.hpp
+++ b/src/include/splash/ParallelDataCollector.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015 Felix Schmitt, Axel Huebl
+ * Copyright 2013-2016 Felix Schmitt, Axel Huebl, Alexander Grund
  *
  * This file is part of libSplash.
  *
@@ -40,6 +40,8 @@
 namespace splash
 {
 
+    class DCGroup;
+
     /**
      * Realizes an IParallelDataCollector which creates a single HDF5 file per iteration
      * for all MPI processes and accesses the file using collective MPI I/O.
@@ -69,6 +71,8 @@ namespace splash
 
         static void listFilesInDir(const std::string baseFilename, std::set<int32_t> &ids)
         throw (DCException);
+        /** @return H5 object id if name!=NULL, else -1 */
+        hid_t openGroup(DCGroup& group, int32_t id, const char* dataName) throw (DCException);
     protected:
 
         typedef struct
@@ -255,6 +259,10 @@ namespace splash
                 int32_t dstID,
                 const char *dstName) throw (DCException);
 
+        DCAttributeInfo* readGlobalAttributeMeta(int32_t id,
+                const char* name,
+                Dimensions *mpiPosition = NULL) throw (DCException);
+
         void readGlobalAttribute(int32_t id,
                 const char* name,
                 void* buf) throw (DCException);
@@ -270,6 +278,11 @@ namespace splash
                 uint32_t ndims,
                 const Dimensions dims,
                 const void* buf) throw (DCException);
+
+        DCAttributeInfo* readAttributeMeta(int32_t id,
+                const char *dataName,
+                const char *attrName,
+                Dimensions *mpiPosition = NULL) throw (DCException);
 
         void readAttribute(int32_t id,
                 const char *dataName,

--- a/src/include/splash/ParallelDataCollector.hpp
+++ b/src/include/splash/ParallelDataCollector.hpp
@@ -263,6 +263,7 @@ namespace splash
                 const char* name,
                 Dimensions *mpiPosition = NULL) throw (DCException);
 
+        SPLASH_DEPRECATED("Use safer readGlobalAttributeInfo")
         void readGlobalAttribute(int32_t id,
                 const char* name,
                 void* buf) throw (DCException);
@@ -279,11 +280,13 @@ namespace splash
                 const Dimensions dims,
                 const void* buf) throw (DCException);
 
+        SPLASH_DEPRECATED("Use safer readAttributeInfo")
         AttributeInfo* readAttributeInfo(int32_t id,
                 const char *dataName,
                 const char *attrName,
                 Dimensions *mpiPosition = NULL) throw (DCException);
 
+        SPLASH_DEPRECATED("Use safer readAttributeInfo")
         void readAttribute(int32_t id,
                 const char *dataName,
                 const char *attrName,
@@ -370,6 +373,7 @@ namespace splash
 
         /* Invalid methods from DataCollector. Do NOT call! */
 
+        SPLASH_DEPRECATED("Use safer readGlobalAttributeInfo")
         void readGlobalAttribute(const char*,
                 void*,
                 Dimensions*) throw (DCException);

--- a/src/include/splash/ParallelDataCollector.hpp
+++ b/src/include/splash/ParallelDataCollector.hpp
@@ -259,7 +259,7 @@ namespace splash
                 int32_t dstID,
                 const char *dstName) throw (DCException);
 
-        DCAttributeInfo* readGlobalAttributeMeta(int32_t id,
+        AttributeInfo* readGlobalAttributeInfo(int32_t id,
                 const char* name,
                 Dimensions *mpiPosition = NULL) throw (DCException);
 
@@ -279,7 +279,7 @@ namespace splash
                 const Dimensions dims,
                 const void* buf) throw (DCException);
 
-        DCAttributeInfo* readAttributeMeta(int32_t id,
+        AttributeInfo* readAttributeInfo(int32_t id,
                 const char *dataName,
                 const char *attrName,
                 Dimensions *mpiPosition = NULL) throw (DCException);

--- a/src/include/splash/SerialDataCollector.hpp
+++ b/src/include/splash/SerialDataCollector.hpp
@@ -302,6 +302,7 @@ namespace splash
                 const char *name,
                 Dimensions *mpiPosition = NULL) throw (DCException);
 
+        SPLASH_DEPRECATED("Use safer readGlobalAttributeInfo")
         void readGlobalAttribute(
                 const char *name,
                 void* data,
@@ -322,6 +323,7 @@ namespace splash
                 const char *attrName,
                 Dimensions *mpiPosition = NULL) throw (DCException);
 
+        SPLASH_DEPRECATED("Use safer readAttributeInfo")
         void readAttribute(int32_t id,
                 const char *dataName,
                 const char *attrName,

--- a/src/include/splash/SerialDataCollector.hpp
+++ b/src/include/splash/SerialDataCollector.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015 Felix Schmitt, Axel Huebl
+ * Copyright 2013-2016 Felix Schmitt, Axel Huebl, Alexander Grund
  *
  * This file is part of libSplash.
  *
@@ -34,6 +34,8 @@
 
 namespace splash
 {
+
+    class DCGroup;
 
     /**
      * Realizes a DataCollector which creates an HDF5 file for each MPI process.
@@ -84,6 +86,11 @@ namespace splash
 
         static herr_t visitObjCallback(hid_t o_id, const char *name,
                 const H5O_info_t *object_info, void *op_data);
+
+        void openCustomGroup(DCGroup& group, Dimensions *mpiPosition = NULL) throw (DCException);
+        /** @return H5 object id if name!=NULL, else -1 */
+        hid_t openGroup(DCGroup& group, int32_t id, const char* name,
+                Dimensions *mpiPosition = NULL) throw (DCException);
 
     protected:
 
@@ -290,6 +297,11 @@ namespace splash
                 Dimensions offset,
                 Dimensions stride) throw (DCException);
 
+        DCAttributeInfo* readGlobalAttributeMeta(
+                int32_t id,
+                const char *name,
+                Dimensions *mpiPosition = NULL) throw (DCException);
+
         void readGlobalAttribute(
                 const char *name,
                 void* data,
@@ -304,6 +316,11 @@ namespace splash
                 uint32_t ndims,
                 const Dimensions dims,
                 const void* data) throw (DCException);
+
+        DCAttributeInfo* readAttributeMeta(int32_t id,
+                const char *dataName,
+                const char *attrName,
+                Dimensions *mpiPosition = NULL) throw (DCException);
 
         void readAttribute(int32_t id,
                 const char *dataName,

--- a/src/include/splash/SerialDataCollector.hpp
+++ b/src/include/splash/SerialDataCollector.hpp
@@ -297,7 +297,7 @@ namespace splash
                 Dimensions offset,
                 Dimensions stride) throw (DCException);
 
-        DCAttributeInfo* readGlobalAttributeMeta(
+        AttributeInfo* readGlobalAttributeInfo(
                 int32_t id,
                 const char *name,
                 Dimensions *mpiPosition = NULL) throw (DCException);
@@ -317,7 +317,7 @@ namespace splash
                 const Dimensions dims,
                 const void* data) throw (DCException);
 
-        DCAttributeInfo* readAttributeMeta(int32_t id,
+        AttributeInfo* readAttributeInfo(int32_t id,
                 const char *dataName,
                 const char *attrName,
                 Dimensions *mpiPosition = NULL) throw (DCException);

--- a/src/include/splash/SerialDataCollector.hpp
+++ b/src/include/splash/SerialDataCollector.hpp
@@ -297,7 +297,7 @@ namespace splash
                 Dimensions offset,
                 Dimensions stride) throw (DCException);
 
-        AttributeInfo* readGlobalAttributeInfo(
+        AttributeInfo readGlobalAttributeInfo(
                 int32_t id,
                 const char *name,
                 Dimensions *mpiPosition = NULL) throw (DCException);
@@ -318,7 +318,7 @@ namespace splash
                 const Dimensions dims,
                 const void* data) throw (DCException);
 
-        AttributeInfo* readAttributeInfo(int32_t id,
+        AttributeInfo readAttributeInfo(int32_t id,
                 const char *dataName,
                 const char *attrName,
                 Dimensions *mpiPosition = NULL) throw (DCException);

--- a/src/include/splash/core/DCAttribute.hpp
+++ b/src/include/splash/core/DCAttribute.hpp
@@ -60,7 +60,7 @@ namespace splash
          *         Must be freed by the caller.
          *
          */
-        static AttributeInfo* readAttributeInfo(const char *name,
+        static AttributeInfo readAttributeInfo(const char *name,
                 hid_t parent) throw (DCException);
 
         /**

--- a/src/include/splash/core/DCAttribute.hpp
+++ b/src/include/splash/core/DCAttribute.hpp
@@ -30,6 +30,8 @@
 
 namespace splash
 {
+    class DCAttributeInfo;
+
     /**
      * Class for static convenience attribute operations.
      * \cond HIDDEN_SYMBOLS
@@ -47,6 +49,19 @@ namespace splash
         static void readAttribute(const char *name,
                 hid_t parent,
                 void *dst) throw (DCException);
+
+        /**
+         * Static method for reading the attribute meta info
+         *
+         * @param name name of the attribute
+         * @param parent parent object to get attribute from
+         * @return Pointer to heap allocated DCAttributeInfo instance
+         *         or NULL if not found.
+         *         Must be freed by the caller.
+         *
+         */
+        static DCAttributeInfo* readAttributeInfo(const char *name,
+                hid_t parent) throw (DCException);
 
         /**
          * Basic static method for writing an attribute.

--- a/src/include/splash/core/DCAttribute.hpp
+++ b/src/include/splash/core/DCAttribute.hpp
@@ -91,7 +91,7 @@ namespace splash
                 const hid_t type,
                 hid_t parent,
                 uint32_t ndims,
-                const Dimensions dims,
+                Dimensions dims,
                 const void *src) throw (DCException);
 
     private:

--- a/src/include/splash/core/DCAttribute.hpp
+++ b/src/include/splash/core/DCAttribute.hpp
@@ -30,7 +30,7 @@
 
 namespace splash
 {
-    class DCAttributeInfo;
+    class AttributeInfo;
 
     /**
      * Class for static convenience attribute operations.
@@ -60,7 +60,7 @@ namespace splash
          *         Must be freed by the caller.
          *
          */
-        static DCAttributeInfo* readAttributeInfo(const char *name,
+        static AttributeInfo* readAttributeInfo(const char *name,
                 hid_t parent) throw (DCException);
 
         /**

--- a/src/include/splash/core/H5IdWrapper.hpp
+++ b/src/include/splash/core/H5IdWrapper.hpp
@@ -33,7 +33,7 @@ namespace splash
     struct H5IdWrapper
     {
         H5IdWrapper(): id_(-1){}
-        H5IdWrapper(hid_t id): id_(id){}
+        explicit H5IdWrapper(hid_t id): id_(id){}
         ~H5IdWrapper()
         {
             close();
@@ -65,7 +65,7 @@ namespace splash
         }
 
         operator hid_t() const { return id_; }
-        bool operator!() const { return id_ < 0; }
+        operator bool() const { return id_ >= 0; }
 
     private:
         // Don't copy!
@@ -82,6 +82,17 @@ namespace splash
     typedef H5IdWrapper<H5Tclose> H5TypeId;
     /** Wrapper for HDF5 type identifiers */
     typedef H5IdWrapper<H5Oclose> H5ObjectId;
+
+    template<H5_DLL herr_t (*T_CloseMethod)(hid_t)>
+    inline bool operator==(const H5IdWrapper<T_CloseMethod>& lhs, const H5IdWrapper<T_CloseMethod>& rhs)
+    {
+        return static_cast<hid_t>(lhs) == static_cast<hid_t>(rhs);
+    }
+    template<H5_DLL herr_t (*T_CloseMethod)(hid_t)>
+    inline bool operator!=(const H5IdWrapper<T_CloseMethod>& lhs, const H5IdWrapper<T_CloseMethod>& rhs)
+    {
+        return !(lhs == rhs);
+    }
 }
 
 #endif /* H5ID_WRAPPER_HPP */

--- a/src/include/splash/core/H5IdWrapper.hpp
+++ b/src/include/splash/core/H5IdWrapper.hpp
@@ -1,0 +1,87 @@
+/**
+ * Copyright 2016 Alexander Grund
+ *
+ * This file is part of libSplash.
+ *
+ * libSplash is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * libSplash is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libSplash.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef H5ID_WRAPPER_HPP
+#define H5ID_WRAPPER_HPP
+
+#include <hdf5.h>
+
+namespace splash
+{
+    /** RAII wrapper for a hid_t (HDF5 identifier)
+     *  Calls T_CloseMethod on destruction and allows implicit conversion */
+    template<H5_DLL herr_t (*T_CloseMethod)(hid_t)>
+    struct H5IdWrapper
+    {
+        H5IdWrapper(): id_(-1){}
+        H5IdWrapper(hid_t id): id_(id){}
+        ~H5IdWrapper()
+        {
+            close();
+        }
+
+        /** Closes the id, resetting it to invalid */
+        void close()
+        {
+            if(id_ < 0)
+                return;
+            T_CloseMethod(id_);
+            id_ = -1;
+        }
+
+        /** Closes the old id and sets a new one */
+        void reset(hid_t id)
+        {
+            close();
+            id_ = id;
+        }
+
+        /** Resets the internal id to invalid without closing it.
+         *  @return Old id */
+        hid_t release()
+        {
+            hid_t id = id_;
+            id_ = -1;
+            return id;
+        }
+
+        operator hid_t() const { return id_; }
+        bool operator!() const { return id_ < 0; }
+
+    private:
+        // Don't copy!
+        H5IdWrapper(const H5IdWrapper&);
+        H5IdWrapper& operator=(const H5IdWrapper&);
+        hid_t id_;
+    };
+
+    /** Wrapper for HDF5 attribute identifiers */
+    typedef H5IdWrapper<H5Aclose> H5AttributeId;
+    /** Wrapper for HDF5 space identifiers */
+    typedef H5IdWrapper<H5Sclose> H5DataspaceId;
+    /** Wrapper for HDF5 type identifiers */
+    typedef H5IdWrapper<H5Tclose> H5TypeId;
+    /** Wrapper for HDF5 type identifiers */
+    typedef H5IdWrapper<H5Oclose> H5ObjectId;
+}
+
+#endif /* H5ID_WRAPPER_HPP */

--- a/src/include/splash/core/H5IdWrapper.hpp
+++ b/src/include/splash/core/H5IdWrapper.hpp
@@ -27,32 +27,103 @@
 
 namespace splash
 {
-    /** RAII wrapper for a hid_t (HDF5 identifier)
-     *  Calls T_CloseMethod on destruction and allows implicit conversion */
-    template<H5_DLL herr_t (*T_CloseMethod)(hid_t)>
-    struct H5IdWrapper
+    
+    namespace policies
     {
+        template<typename T>
+        struct NoCopy
+        {
+            static T copy(const T&)
+            {
+                // Make it depend on template parameter
+                static char copyNotAllowed[sizeof(T) ? -1 : 0];
+                (void) copyNotAllowed;
+            }
+            
+            static bool release(const T&)
+            {
+                return true;
+            }
+        };
+
+        template<typename T>
+        struct RefCounted
+        {
+            RefCounted(): refCt_(new unsigned)
+            {
+                *refCt_ = 1;
+            }
+            
+            T copy(const T& obj)
+            {
+                ++*refCt_;
+                return obj;
+            }
+            
+            bool release(const T&)
+            {
+                if(!--*refCt_)
+                {
+                    delete refCt_;
+                    refCt_ = NULL;
+                    return true;
+                }
+                return false;
+            }
+            
+            friend void swap(RefCounted& lhs, RefCounted& rhs)
+            {
+                std::swap(lhs.refCt_, rhs.refCt_);
+            }
+        private:
+            unsigned* refCt_;
+        };
+    }
+    
+    /** RAII wrapper for a hid_t (HDF5 identifier)
+     *  Calls T_CloseMethod on destruction and allows implicit conversion
+     *  Calls T_DestructionPolicy::copy on copy which should return the id to store
+     *  Calls T_DestructionPolicy::release on close/destruction which should return true if the handle should be closed
+     */
+    template<H5_DLL herr_t (*T_CloseMethod)(hid_t), template<class> class T_DestructionPolicy>
+    struct H5IdWrapper: public T_DestructionPolicy<hid_t>
+    {
+        typedef T_DestructionPolicy<hid_t> DestructionPolicy;
+        
         H5IdWrapper(): id_(-1){}
         explicit H5IdWrapper(hid_t id): id_(id){}
+        H5IdWrapper(const H5IdWrapper& rhs): DestructionPolicy(rhs)
+        {
+            id_ = DestructionPolicy::copy(rhs.id_);
+        }
+
+        H5IdWrapper& operator=(const H5IdWrapper& rhs)
+        {
+            H5IdWrapper tmp(rhs);
+            swap(*this, tmp);
+            return *this;
+        }
+
         ~H5IdWrapper()
         {
-            close();
+            if(DestructionPolicy::release(id_))
+            {
+                if(id_ >= 0)
+                    T_CloseMethod(id_);
+            }
         }
 
-        /** Closes the id, resetting it to invalid */
+        /** Sets the id to invalid closing it if required */
         void close()
         {
-            if(id_ < 0)
-                return;
-            T_CloseMethod(id_);
-            id_ = -1;
+            reset(-1);
         }
 
-        /** Closes the old id and sets a new one */
+        /** Resets the id closing the current one if required */
         void reset(hid_t id)
         {
-            close();
-            id_ = id;
+            H5IdWrapper tmp(id);
+            swap(*this, tmp);
         }
 
         /** Resets the internal id to invalid without closing it.
@@ -66,30 +137,37 @@ namespace splash
 
         operator hid_t() const { return id_; }
         operator bool() const { return id_ >= 0; }
+        
+        friend void swap(H5IdWrapper& lhs, H5IdWrapper& rhs)
+        {
+            std::swap(lhs.id_, rhs.id_);
+            std::swap(static_cast<DestructionPolicy&>(lhs), static_cast<DestructionPolicy&>(rhs));
+        }
 
     private:
-        // Don't copy!
-        H5IdWrapper(const H5IdWrapper&);
-        H5IdWrapper& operator=(const H5IdWrapper&);
         hid_t id_;
     };
 
     /** Wrapper for HDF5 attribute identifiers */
-    typedef H5IdWrapper<H5Aclose> H5AttributeId;
+    typedef H5IdWrapper<H5Aclose, policies::NoCopy> H5AttributeId;
+    typedef H5IdWrapper<H5Aclose, policies::RefCounted> H5AttributeIdRefCt;
     /** Wrapper for HDF5 space identifiers */
-    typedef H5IdWrapper<H5Sclose> H5DataspaceId;
+    typedef H5IdWrapper<H5Sclose, policies::NoCopy> H5DataspaceId;
+    typedef H5IdWrapper<H5Sclose, policies::RefCounted> H5DataspaceIdRefCt;
     /** Wrapper for HDF5 type identifiers */
-    typedef H5IdWrapper<H5Tclose> H5TypeId;
+    typedef H5IdWrapper<H5Tclose, policies::NoCopy> H5TypeId;
+    typedef H5IdWrapper<H5Tclose, policies::RefCounted> H5TypeIdRefCt;
     /** Wrapper for HDF5 type identifiers */
-    typedef H5IdWrapper<H5Oclose> H5ObjectId;
+    typedef H5IdWrapper<H5Oclose, policies::NoCopy> H5ObjectId;
+    typedef H5IdWrapper<H5Oclose, policies::RefCounted> H5ObjectIdRefCt;
 
-    template<H5_DLL herr_t (*T_CloseMethod)(hid_t)>
-    inline bool operator==(const H5IdWrapper<T_CloseMethod>& lhs, const H5IdWrapper<T_CloseMethod>& rhs)
+    template<H5_DLL herr_t (*T_CloseMethod)(hid_t), template<class> class T_DestructionPolicy>
+    inline bool operator==(const H5IdWrapper<T_CloseMethod, T_DestructionPolicy>& lhs, const H5IdWrapper<T_CloseMethod, T_DestructionPolicy>& rhs)
     {
         return static_cast<hid_t>(lhs) == static_cast<hid_t>(rhs);
     }
-    template<H5_DLL herr_t (*T_CloseMethod)(hid_t)>
-    inline bool operator!=(const H5IdWrapper<T_CloseMethod>& lhs, const H5IdWrapper<T_CloseMethod>& rhs)
+    template<H5_DLL herr_t (*T_CloseMethod)(hid_t), template<class> class T_DestructionPolicy>
+    inline bool operator!=(const H5IdWrapper<T_CloseMethod, T_DestructionPolicy>& lhs, const H5IdWrapper<T_CloseMethod, T_DestructionPolicy>& rhs)
     {
         return !(lhs == rhs);
     }

--- a/src/include/splash/core/splashMacros.hpp
+++ b/src/include/splash/core/splashMacros.hpp
@@ -1,0 +1,37 @@
+/**
+ * Copyright 2016 Alexander Grund
+ *
+ * This file is part of libSplash.
+ *
+ * libSplash is free software: you can redistribute it and/or modify
+ * it under the terms of of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * libSplash is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with libSplash.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef SPLASH_MACROS_HPP
+#define SPLASH_MACROS_HPP
+
+// Mark a function as deprecated: `SPLASH_DEPRECATED("Use bar instead") void foo();`
+#ifdef __clang__
+#   define SPLASH_DEPRECATED(msg) __attribute__((deprecated(msg)))
+#elif defined(__GNUC__)
+#   define SPLASH_DEPRECATED(msg) __attribute__((deprecated))
+#elif defined(_MSC_VER)
+#   define SPLASH_DEPRECATED(msg) __declspec(deprecated)
+#else
+#   define SPLASH_DEPRECATED(msg)
+#endif
+
+#endif /* SPLASH_MACROS_HPP */

--- a/src/include/splash/splash_parallel.h
+++ b/src/include/splash/splash_parallel.h
@@ -35,6 +35,6 @@
 #include "splash/ParallelDomainCollector.hpp"
 
 #include "splash/basetypes/basetypes.hpp"
-#include "splash/DCAttributeInfo.hpp"
+#include "splash/AttributeInfo.hpp"
 
 #endif /* SPLASH_H */

--- a/src/include/splash/splash_parallel.h
+++ b/src/include/splash/splash_parallel.h
@@ -35,5 +35,6 @@
 #include "splash/ParallelDomainCollector.hpp"
 
 #include "splash/basetypes/basetypes.hpp"
+#include "splash/DCAttributeInfo.hpp"
 
 #endif /* SPLASH_H */

--- a/src/include/splash/splash_serial.h
+++ b/src/include/splash/splash_serial.h
@@ -31,6 +31,6 @@
 #include "splash/DomainCollector.hpp"
 
 #include "splash/basetypes/basetypes.hpp"
-#include "splash/DCAttributeInfo.hpp"
+#include "splash/AttributeInfo.hpp"
 
 #endif /* SPLASH_H */

--- a/tests/AttributesTest.cpp
+++ b/tests/AttributesTest.cpp
@@ -186,7 +186,7 @@ void AttributesTest::testDataAttributes()
 }
 
 // Delete old info, read new info and check validity (reduce noise in test code)
-#define READ_ATTR_META(name, group) delete info; info = NULL;                                 \
+#define READ_ATTR_META(name, group) delete info; info = NULL;                           \
                              info = dataCollector->readAttributeMeta(10, group, #name); \
                              CPPUNIT_ASSERT(info);
 
@@ -226,34 +226,40 @@ void AttributesTest::testAttributesMeta()
     CPPUNIT_ASSERT_EQUAL(sizeof(intVal), info->getMemSize());
     // Note: This is the file saved type. ColTypeInt will resolve to the generic variant
     CPPUNIT_ASSERT(typeid(info->getType()) == typeid(ColTypeInt32));
+    CPPUNIT_ASSERT(!info->isVarSize());
 
     READ_ATTR_META(intVal, NULL);
     CPPUNIT_ASSERT(info->isScalar());
     CPPUNIT_ASSERT_EQUAL(sizeof(intVal), info->getMemSize());
     // Note: This is the file saved type. ColTypeInt will resolve to the generic variant
     CPPUNIT_ASSERT(typeid(info->getType()) == typeid(ColTypeInt32));
+    CPPUNIT_ASSERT(!info->isVarSize());
 
     READ_ATTR_META(varLenStr, NULL);
     CPPUNIT_ASSERT(info->isScalar());
     CPPUNIT_ASSERT_EQUAL(sizeof(varLenStr), info->getMemSize());
     CPPUNIT_ASSERT(typeid(info->getType()) == typeid(ctString));
+    CPPUNIT_ASSERT(info->isVarSize());
 
     READ_ATTR_META(fixedLenStr, NULL);
     CPPUNIT_ASSERT(info->isScalar());
     CPPUNIT_ASSERT_EQUAL(sizeof(fixedLenStr), info->getMemSize());
     CPPUNIT_ASSERT(typeid(info->getType()) == typeid(ctString4));
+    CPPUNIT_ASSERT(!info->isVarSize());
 
     READ_ATTR_META(intVal, "group");
     CPPUNIT_ASSERT(info->isScalar());
     CPPUNIT_ASSERT_EQUAL(sizeof(intVal), info->getMemSize());
     // Note: This is the file saved type. ColTypeInt will resolve to the generic variant
     CPPUNIT_ASSERT(typeid(info->getType()) == typeid(ColTypeInt32));
+    CPPUNIT_ASSERT(!info->isVarSize());
 
     READ_ATTR_META(charVal, "group");
     CPPUNIT_ASSERT(info->isScalar());
     CPPUNIT_ASSERT_EQUAL(sizeof(charVal), info->getMemSize());
     // Note: Native char resolves to either Int8 or UInt8
     CPPUNIT_ASSERT(typeid(info->getType()) == typeid(ColTypeInt8) || typeid(info->getType()) == typeid(ColTypeUInt8));
+    CPPUNIT_ASSERT(!info->isVarSize());
 
     delete info;
     dataCollector->close();
@@ -304,6 +310,7 @@ void AttributesTest::testArrayAttributesMeta()
     double doubleArray[7] = {-3.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0};
     Dimensions dim(104, 0, 2);
     const int intVal= 42;
+    const char strArray[6] = {"x\0y\0z"};
 
     dataCollector->writeAttribute(10, ctInt, NULL, "intVal", 1u, Dimensions(1, 1, 1), &intVal);
     dataCollector->writeAttribute(10, ctInt, NULL, "intVal2", 3u, Dimensions(1, 1, 1), &intVal);
@@ -312,6 +319,7 @@ void AttributesTest::testArrayAttributesMeta()
     dataCollector->writeAttribute(10, ctInt, NULL, "int3Array3", 3u, Dimensions(1, 1, 3), int3Array);
     dataCollector->writeAttribute(10, ctDimArray, NULL, "dim", dim.getPointer());
     dataCollector->writeAttribute(10, ctDouble, NULL, "doubleArray", 1u, Dimensions(7,1,1), doubleArray);
+    dataCollector->writeAttribute(10, ColTypeString(1), NULL, "strArray", 1u, Dimensions(3,1,1), strArray);
 
     // Reopen in read mode
     dataCollector->close();
@@ -325,6 +333,7 @@ void AttributesTest::testArrayAttributesMeta()
     CPPUNIT_ASSERT_EQUAL(sizeof(intVal), info->getMemSize());
     // Note: This is the file saved type. ColTypeInt will resolve to the generic variant
     CPPUNIT_ASSERT(typeid(info->getType()) == typeid(ColTypeInt32));
+    CPPUNIT_ASSERT(!info->isVarSize());
 
     READ_ATTR_META(intVal2, NULL);
     CPPUNIT_ASSERT(!info->isScalar());
@@ -333,11 +342,13 @@ void AttributesTest::testArrayAttributesMeta()
     CPPUNIT_ASSERT(typeid(info->getType()) == typeid(ColTypeInt32));
     CPPUNIT_ASSERT_EQUAL(3u, info->getNDims());
     CPPUNIT_ASSERT_EQUAL(Dimensions(1, 1, 1), info->getDims());
+    CPPUNIT_ASSERT(!info->isVarSize());
 
     READ_ATTR_META(int3Array1, NULL);
     CPPUNIT_ASSERT(info->isScalar());
     CPPUNIT_ASSERT_EQUAL(sizeof(int3Array), info->getMemSize());
     CPPUNIT_ASSERT(typeid(info->getType()) == typeid(ctInt3Array));
+    CPPUNIT_ASSERT(!info->isVarSize());
 
     READ_ATTR_META(int3Array2, NULL);
     CPPUNIT_ASSERT(!info->isScalar());
@@ -346,6 +357,7 @@ void AttributesTest::testArrayAttributesMeta()
     CPPUNIT_ASSERT(typeid(info->getType()) == typeid(ColTypeInt32));
     CPPUNIT_ASSERT_EQUAL(1u, info->getNDims());
     CPPUNIT_ASSERT_EQUAL(Dimensions(3, 1, 1), info->getDims());
+    CPPUNIT_ASSERT(!info->isVarSize());
 
     READ_ATTR_META(int3Array3, NULL);
     CPPUNIT_ASSERT(!info->isScalar());
@@ -354,6 +366,7 @@ void AttributesTest::testArrayAttributesMeta()
     CPPUNIT_ASSERT(typeid(info->getType()) == typeid(ColTypeInt32));
     CPPUNIT_ASSERT_EQUAL(3u, info->getNDims());
     CPPUNIT_ASSERT_EQUAL(Dimensions(1, 1, 3), info->getDims());
+    CPPUNIT_ASSERT(!info->isVarSize());
 
     READ_ATTR_META(dim, NULL);
     CPPUNIT_ASSERT(info->isScalar());
@@ -361,6 +374,7 @@ void AttributesTest::testArrayAttributesMeta()
     CPPUNIT_ASSERT(typeid(info->getType()) == typeid(ctDimArray));
     CPPUNIT_ASSERT_EQUAL(1u, info->getNDims());
     CPPUNIT_ASSERT_EQUAL(Dimensions(1, 1, 1), info->getDims());
+    CPPUNIT_ASSERT(!info->isVarSize());
 
     READ_ATTR_META(doubleArray, NULL);
     CPPUNIT_ASSERT(!info->isScalar());
@@ -368,6 +382,15 @@ void AttributesTest::testArrayAttributesMeta()
     CPPUNIT_ASSERT(typeid(info->getType()) == typeid(ctDouble));
     CPPUNIT_ASSERT_EQUAL(1u, info->getNDims());
     CPPUNIT_ASSERT_EQUAL(Dimensions(7, 1, 1), info->getDims());
+    CPPUNIT_ASSERT(!info->isVarSize());
+
+    READ_ATTR_META(strArray, NULL);
+    CPPUNIT_ASSERT(!info->isScalar());
+    CPPUNIT_ASSERT_EQUAL(sizeof(strArray), info->getMemSize());
+    CPPUNIT_ASSERT(typeid(info->getType()) == typeid(ColTypeString));
+    CPPUNIT_ASSERT_EQUAL(1u, info->getNDims());
+    CPPUNIT_ASSERT_EQUAL(Dimensions(3, 1, 1), info->getDims());
+    CPPUNIT_ASSERT(!info->isVarSize());
 
     delete info;
     dataCollector->close();

--- a/tests/AttributesTest.cpp
+++ b/tests/AttributesTest.cpp
@@ -190,11 +190,6 @@ void AttributesTest::testDataAttributes()
     dataCollector->close();
 }
 
-// Delete old info, read new info and check validity (reduce noise in test code)
-#define READ_ATTR_META(name, group) delete info; info = NULL;                           \
-                             info = dataCollector->readAttributeInfo(10, group, #name); \
-                             CPPUNIT_ASSERT(info);
-
 void AttributesTest::testAttributesMeta()
 {
     DataCollector::FileCreationAttr attr;
@@ -227,8 +222,7 @@ void AttributesTest::testAttributesMeta()
     attr.fileAccType = DataCollector::FAT_READ;
     dataCollector->open(TEST_FILE_META, attr);
 
-    AttributeInfo* info = NULL;
-    info = dataCollector->readGlobalAttributeInfo(10, "intValGlob");
+    AttributeInfo info = dataCollector->readGlobalAttributeInfo(10, "intValGlob");
     CPPUNIT_ASSERT(info->isScalar());
     CPPUNIT_ASSERT_EQUAL(sizeof(intVal), info->getMemSize());
     // Note: This is the file saved type. ColTypeInt will resolve to the generic variant
@@ -238,7 +232,7 @@ void AttributesTest::testAttributesMeta()
     info->read(ctInt, &intValRead);
     CPPUNIT_ASSERT_EQUAL(intValGlob, intValRead);
 
-    READ_ATTR_META(intVal, NULL);
+    info = dataCollector->readAttributeInfo(10, NULL, "intVal");
     CPPUNIT_ASSERT(info->isScalar());
     CPPUNIT_ASSERT_EQUAL(sizeof(intVal), info->getMemSize());
     // Note: This is the file saved type. ColTypeInt will resolve to the generic variant
@@ -248,7 +242,7 @@ void AttributesTest::testAttributesMeta()
     info->read(ctInt, &intValRead);
     CPPUNIT_ASSERT_EQUAL(intVal, intValRead);
 
-    READ_ATTR_META(varLenStr, NULL);
+    info = dataCollector->readAttributeInfo(10, NULL, "varLenStr");
     CPPUNIT_ASSERT(info->isScalar());
     CPPUNIT_ASSERT_EQUAL(sizeof(varLenStr), info->getMemSize());
     CPPUNIT_ASSERT(typeid(info->getType()) == typeid(ctString));
@@ -258,7 +252,7 @@ void AttributesTest::testAttributesMeta()
     info->read(ctString, &varLenStrRead);
     CPPUNIT_ASSERT(strcmp(varLenStr, varLenStrRead) == 0);
 
-    READ_ATTR_META(fixedLenStr, NULL);
+    info = dataCollector->readAttributeInfo(10, NULL, "fixedLenStr");
     CPPUNIT_ASSERT(info->isScalar());
     CPPUNIT_ASSERT_EQUAL(sizeof(fixedLenStr), info->getMemSize());
     CPPUNIT_ASSERT(typeid(info->getType()) == typeid(ctString4));
@@ -268,7 +262,7 @@ void AttributesTest::testAttributesMeta()
     info->read(ctString4, &fixedLenStrRead[0]);
     CPPUNIT_ASSERT(strcmp(fixedLenStr, &fixedLenStrRead[0]) == 0);
 
-    READ_ATTR_META(intValGroup, "group");
+    info = dataCollector->readAttributeInfo(10, "group", "intValGroup");
     CPPUNIT_ASSERT(info->isScalar());
     CPPUNIT_ASSERT_EQUAL(sizeof(intVal), info->getMemSize());
     // Note: This is the file saved type. ColTypeInt will resolve to the generic variant
@@ -278,7 +272,7 @@ void AttributesTest::testAttributesMeta()
     info->read(ctInt, &intValGroupRead);
     CPPUNIT_ASSERT_EQUAL(intValGroup, intValGroupRead);
 
-    READ_ATTR_META(charVal, "group");
+    info = dataCollector->readAttributeInfo(10, "group", "charVal");
     CPPUNIT_ASSERT(info->isScalar());
     CPPUNIT_ASSERT_EQUAL(sizeof(charVal), info->getMemSize());
     // Note: Native char resolves to either Int8 or UInt8
@@ -362,9 +356,7 @@ void AttributesTest::testArrayAttributesMeta()
     Dimensions dimRead(0,0,0);
     char strArrayRead[6] = "\0\0\0\0\0";
 
-    AttributeInfo* info = NULL;
-
-    READ_ATTR_META(intVal, NULL);
+    AttributeInfo info = dataCollector->readAttributeInfo(10, NULL, "intVal");
     CPPUNIT_ASSERT(info->isScalar());
     CPPUNIT_ASSERT_EQUAL(sizeof(intVal), info->getMemSize());
     // Note: This is the file saved type. ColTypeInt will resolve to the generic variant
@@ -373,7 +365,7 @@ void AttributesTest::testArrayAttributesMeta()
     info->read(&intValRead, sizeof(intValRead));
     CPPUNIT_ASSERT_EQUAL(intVal, intValRead);
 
-    READ_ATTR_META(intVal2, NULL);
+    info = dataCollector->readAttributeInfo(10, NULL, "intVal2");
     CPPUNIT_ASSERT(!info->isScalar());
     CPPUNIT_ASSERT_EQUAL(sizeof(intVal), info->getMemSize());
     // Note: This is the file saved type. ColTypeInt will resolve to the generic variant
@@ -384,7 +376,7 @@ void AttributesTest::testArrayAttributesMeta()
     info->read(&intValRead, sizeof(intValRead));
     CPPUNIT_ASSERT_EQUAL(intVal2, intValRead);
 
-    READ_ATTR_META(int3Array1, NULL);
+    info = dataCollector->readAttributeInfo(10, NULL, "int3Array1");
     CPPUNIT_ASSERT(info->isScalar());
     CPPUNIT_ASSERT_EQUAL(sizeof(int3Array), info->getMemSize());
     CPPUNIT_ASSERT(typeid(info->getType()) == typeid(ctInt3Array));
@@ -392,7 +384,7 @@ void AttributesTest::testArrayAttributesMeta()
     info->read(&int3ArrayRead, sizeof(int3ArrayRead));
     CPPUNIT_ASSERT(memcmp(int3Array, int3ArrayRead, sizeof(int3ArrayRead)) == 0);
 
-    READ_ATTR_META(int3Array2, NULL);
+    info = dataCollector->readAttributeInfo(10, NULL, "int3Array2");
     CPPUNIT_ASSERT(!info->isScalar());
     CPPUNIT_ASSERT_EQUAL(sizeof(int3Array), info->getMemSize());
     // Note: This is the file saved type. ColTypeInt will resolve to the generic variant
@@ -403,7 +395,7 @@ void AttributesTest::testArrayAttributesMeta()
     info->read(&int3ArrayRead, sizeof(int3ArrayRead));
     CPPUNIT_ASSERT(memcmp(int3Array2, int3ArrayRead, sizeof(int3ArrayRead)) == 0);
 
-    READ_ATTR_META(int3Array3, NULL);
+    info = dataCollector->readAttributeInfo(10, NULL, "int3Array3");
     CPPUNIT_ASSERT(!info->isScalar());
     CPPUNIT_ASSERT_EQUAL(sizeof(int3Array), info->getMemSize());
     // Note: This is the file saved type. ColTypeInt will resolve to the generic variant
@@ -414,7 +406,7 @@ void AttributesTest::testArrayAttributesMeta()
     info->read(&int3ArrayRead, sizeof(int3ArrayRead));
     CPPUNIT_ASSERT(memcmp(int3Array3, int3ArrayRead, sizeof(int3ArrayRead)) == 0);
 
-    READ_ATTR_META(dim, NULL);
+    info = dataCollector->readAttributeInfo(10, NULL, "dim");
     CPPUNIT_ASSERT(info->isScalar());
     CPPUNIT_ASSERT_EQUAL(sizeof(dim), info->getMemSize());
     CPPUNIT_ASSERT(typeid(info->getType()) == typeid(ctDimArray));
@@ -424,7 +416,7 @@ void AttributesTest::testArrayAttributesMeta()
     info->read(&dimRead, dimRead.getSize());
     CPPUNIT_ASSERT_EQUAL(dim, dimRead);
 
-    READ_ATTR_META(doubleArray, NULL);
+    info = dataCollector->readAttributeInfo(10, NULL, "doubleArray");
     CPPUNIT_ASSERT(!info->isScalar());
     CPPUNIT_ASSERT_EQUAL(sizeof(doubleArray), info->getMemSize());
     CPPUNIT_ASSERT(typeid(info->getType()) == typeid(ctDouble));
@@ -434,7 +426,7 @@ void AttributesTest::testArrayAttributesMeta()
     info->read(&doubleArrayRead, sizeof(doubleArrayRead));
     CPPUNIT_ASSERT(memcmp(doubleArray, doubleArrayRead, sizeof(doubleArrayRead)) == 0);
 
-    READ_ATTR_META(strArray, NULL);
+    info = dataCollector->readAttributeInfo(10, NULL, "strArray");
     CPPUNIT_ASSERT(!info->isScalar());
     CPPUNIT_ASSERT_EQUAL(sizeof(strArray), info->getMemSize());
     CPPUNIT_ASSERT(typeid(info->getType()) == typeid(ColTypeString));

--- a/tests/AttributesTest.cpp
+++ b/tests/AttributesTest.cpp
@@ -223,66 +223,65 @@ void AttributesTest::testAttributesMeta()
     dataCollector->open(TEST_FILE_META, attr);
 
     AttributeInfo info = dataCollector->readGlobalAttributeInfo(10, "intValGlob");
-    CPPUNIT_ASSERT(info->isScalar());
-    CPPUNIT_ASSERT_EQUAL(sizeof(intVal), info->getMemSize());
+    CPPUNIT_ASSERT(info.isScalar());
+    CPPUNIT_ASSERT_EQUAL(sizeof(intVal), info.getMemSize());
     // Note: This is the file saved type. ColTypeInt will resolve to the generic variant
-    CPPUNIT_ASSERT(typeid(info->getType()) == typeid(ColTypeInt32));
-    CPPUNIT_ASSERT(!info->isVarSize());
+    CPPUNIT_ASSERT(dynamic_cast<const ColTypeInt32*>(&info.getType()));
+    CPPUNIT_ASSERT(!info.isVarSize());
     int intValRead = 0;
-    info->read(ctInt, &intValRead);
+    info.read(ctInt, &intValRead);
     CPPUNIT_ASSERT_EQUAL(intValGlob, intValRead);
 
     info = dataCollector->readAttributeInfo(10, NULL, "intVal");
-    CPPUNIT_ASSERT(info->isScalar());
-    CPPUNIT_ASSERT_EQUAL(sizeof(intVal), info->getMemSize());
+    CPPUNIT_ASSERT(info.isScalar());
+    CPPUNIT_ASSERT_EQUAL(sizeof(intVal), info.getMemSize());
     // Note: This is the file saved type. ColTypeInt will resolve to the generic variant
-    CPPUNIT_ASSERT(typeid(info->getType()) == typeid(ColTypeInt32));
-    CPPUNIT_ASSERT(!info->isVarSize());
+    CPPUNIT_ASSERT(dynamic_cast<const ColTypeInt32*>(&info.getType()));
+    CPPUNIT_ASSERT(!info.isVarSize());
     intValRead = 0;
-    info->read(ctInt, &intValRead);
+    info.read(ctInt, &intValRead);
     CPPUNIT_ASSERT_EQUAL(intVal, intValRead);
 
     info = dataCollector->readAttributeInfo(10, NULL, "varLenStr");
-    CPPUNIT_ASSERT(info->isScalar());
-    CPPUNIT_ASSERT_EQUAL(sizeof(varLenStr), info->getMemSize());
-    CPPUNIT_ASSERT(typeid(info->getType()) == typeid(ctString));
-    CPPUNIT_ASSERT(info->isVarSize());
+    CPPUNIT_ASSERT(info.isScalar());
+    CPPUNIT_ASSERT_EQUAL(sizeof(varLenStr), info.getMemSize());
+    CPPUNIT_ASSERT(dynamic_cast<const ColTypeString*>(&info.getType()));
+    CPPUNIT_ASSERT(info.isVarSize());
     // Note: API returns a pointer to the string!
     const char* varLenStrRead = NULL;
-    info->read(ctString, &varLenStrRead);
+    info.read(ctString, &varLenStrRead);
     CPPUNIT_ASSERT(strcmp(varLenStr, varLenStrRead) == 0);
 
     info = dataCollector->readAttributeInfo(10, NULL, "fixedLenStr");
-    CPPUNIT_ASSERT(info->isScalar());
-    CPPUNIT_ASSERT_EQUAL(sizeof(fixedLenStr), info->getMemSize());
-    CPPUNIT_ASSERT(typeid(info->getType()) == typeid(ctString4));
-    CPPUNIT_ASSERT(!info->isVarSize());
+    CPPUNIT_ASSERT(info.isScalar());
+    CPPUNIT_ASSERT_EQUAL(sizeof(fixedLenStr), info.getMemSize());
+    CPPUNIT_ASSERT(dynamic_cast<const ColTypeString*>(&info.getType()));
+    CPPUNIT_ASSERT(!info.isVarSize());
     // Note: API returns string data
-    std::vector<char> fixedLenStrRead(info->getMemSize());
-    info->read(ctString4, &fixedLenStrRead[0]);
+    std::vector<char> fixedLenStrRead(info.getMemSize());
+    info.read(ctString4, &fixedLenStrRead[0]);
     CPPUNIT_ASSERT(strcmp(fixedLenStr, &fixedLenStrRead[0]) == 0);
 
     info = dataCollector->readAttributeInfo(10, "group", "intValGroup");
-    CPPUNIT_ASSERT(info->isScalar());
-    CPPUNIT_ASSERT_EQUAL(sizeof(intVal), info->getMemSize());
+    CPPUNIT_ASSERT(info.isScalar());
+    CPPUNIT_ASSERT_EQUAL(sizeof(intVal), info.getMemSize());
     // Note: This is the file saved type. ColTypeInt will resolve to the generic variant
-    CPPUNIT_ASSERT(typeid(info->getType()) == typeid(ColTypeInt32));
-    CPPUNIT_ASSERT(!info->isVarSize());
+    CPPUNIT_ASSERT(dynamic_cast<const ColTypeInt32*>(&info.getType()));
+    CPPUNIT_ASSERT(!info.isVarSize());
     int intValGroupRead = 0;
-    info->read(ctInt, &intValGroupRead);
+    info.read(ctInt, &intValGroupRead);
     CPPUNIT_ASSERT_EQUAL(intValGroup, intValGroupRead);
 
     info = dataCollector->readAttributeInfo(10, "group", "charVal");
-    CPPUNIT_ASSERT(info->isScalar());
-    CPPUNIT_ASSERT_EQUAL(sizeof(charVal), info->getMemSize());
+    CPPUNIT_ASSERT(info.isScalar());
+    CPPUNIT_ASSERT_EQUAL(sizeof(charVal), info.getMemSize());
     // Note: Native char resolves to either Int8 or UInt8
-    CPPUNIT_ASSERT(typeid(info->getType()) == typeid(ColTypeInt8) || typeid(info->getType()) == typeid(ColTypeUInt8));
-    CPPUNIT_ASSERT(!info->isVarSize());
+    CPPUNIT_ASSERT(dynamic_cast<const ColTypeInt8*>(&info.getType()) || dynamic_cast<const ColTypeUInt8*>(&info.getType()));
+    CPPUNIT_ASSERT(!info.isVarSize());
     char charValRead = 0;
-    info->read(ctChar, &charValRead);
+    info.read(ctChar, &charValRead);
     CPPUNIT_ASSERT_EQUAL(charVal, charValRead);
 
-    delete info;
     dataCollector->close();
 }
 
@@ -357,85 +356,84 @@ void AttributesTest::testArrayAttributesMeta()
     char strArrayRead[6] = "\0\0\0\0\0";
 
     AttributeInfo info = dataCollector->readAttributeInfo(10, NULL, "intVal");
-    CPPUNIT_ASSERT(info->isScalar());
-    CPPUNIT_ASSERT_EQUAL(sizeof(intVal), info->getMemSize());
+    CPPUNIT_ASSERT(info.isScalar());
+    CPPUNIT_ASSERT_EQUAL(sizeof(intVal), info.getMemSize());
     // Note: This is the file saved type. ColTypeInt will resolve to the generic variant
-    CPPUNIT_ASSERT(typeid(info->getType()) == typeid(ColTypeInt32));
-    CPPUNIT_ASSERT(!info->isVarSize());
-    info->read(&intValRead, sizeof(intValRead));
+    CPPUNIT_ASSERT(dynamic_cast<const ColTypeInt32*>(&info.getType()));
+    CPPUNIT_ASSERT(!info.isVarSize());
+    info.read(&intValRead, sizeof(intValRead));
     CPPUNIT_ASSERT_EQUAL(intVal, intValRead);
 
     info = dataCollector->readAttributeInfo(10, NULL, "intVal2");
-    CPPUNIT_ASSERT(!info->isScalar());
-    CPPUNIT_ASSERT_EQUAL(sizeof(intVal), info->getMemSize());
+    CPPUNIT_ASSERT(!info.isScalar());
+    CPPUNIT_ASSERT_EQUAL(sizeof(intVal), info.getMemSize());
     // Note: This is the file saved type. ColTypeInt will resolve to the generic variant
-    CPPUNIT_ASSERT(typeid(info->getType()) == typeid(ColTypeInt32));
-    CPPUNIT_ASSERT_EQUAL(3u, info->getNDims());
-    CPPUNIT_ASSERT_EQUAL(Dimensions(1, 1, 1), info->getDims());
-    CPPUNIT_ASSERT(!info->isVarSize());
-    info->read(&intValRead, sizeof(intValRead));
+    CPPUNIT_ASSERT(dynamic_cast<const ColTypeInt32*>(&info.getType()));
+    CPPUNIT_ASSERT_EQUAL(3u, info.getNDims());
+    CPPUNIT_ASSERT_EQUAL(Dimensions(1, 1, 1), info.getDims());
+    CPPUNIT_ASSERT(!info.isVarSize());
+    info.read(&intValRead, sizeof(intValRead));
     CPPUNIT_ASSERT_EQUAL(intVal2, intValRead);
 
     info = dataCollector->readAttributeInfo(10, NULL, "int3Array1");
-    CPPUNIT_ASSERT(info->isScalar());
-    CPPUNIT_ASSERT_EQUAL(sizeof(int3Array), info->getMemSize());
-    CPPUNIT_ASSERT(typeid(info->getType()) == typeid(ctInt3Array));
-    CPPUNIT_ASSERT(!info->isVarSize());
-    info->read(&int3ArrayRead, sizeof(int3ArrayRead));
+    CPPUNIT_ASSERT(info.isScalar());
+    CPPUNIT_ASSERT_EQUAL(sizeof(int3Array), info.getMemSize());
+    CPPUNIT_ASSERT(dynamic_cast<const ColTypeInt3Array*>(&info.getType()));
+    CPPUNIT_ASSERT(!info.isVarSize());
+    info.read(&int3ArrayRead, sizeof(int3ArrayRead));
     CPPUNIT_ASSERT(memcmp(int3Array, int3ArrayRead, sizeof(int3ArrayRead)) == 0);
 
     info = dataCollector->readAttributeInfo(10, NULL, "int3Array2");
-    CPPUNIT_ASSERT(!info->isScalar());
-    CPPUNIT_ASSERT_EQUAL(sizeof(int3Array), info->getMemSize());
+    CPPUNIT_ASSERT(!info.isScalar());
+    CPPUNIT_ASSERT_EQUAL(sizeof(int3Array), info.getMemSize());
     // Note: This is the file saved type. ColTypeInt will resolve to the generic variant
-    CPPUNIT_ASSERT(typeid(info->getType()) == typeid(ColTypeInt32));
-    CPPUNIT_ASSERT_EQUAL(1u, info->getNDims());
-    CPPUNIT_ASSERT_EQUAL(Dimensions(3, 1, 1), info->getDims());
-    CPPUNIT_ASSERT(!info->isVarSize());
-    info->read(&int3ArrayRead, sizeof(int3ArrayRead));
+    CPPUNIT_ASSERT(dynamic_cast<const ColTypeInt32*>(&info.getType()));
+    CPPUNIT_ASSERT_EQUAL(1u, info.getNDims());
+    CPPUNIT_ASSERT_EQUAL(Dimensions(3, 1, 1), info.getDims());
+    CPPUNIT_ASSERT(!info.isVarSize());
+    info.read(&int3ArrayRead, sizeof(int3ArrayRead));
     CPPUNIT_ASSERT(memcmp(int3Array2, int3ArrayRead, sizeof(int3ArrayRead)) == 0);
 
     info = dataCollector->readAttributeInfo(10, NULL, "int3Array3");
-    CPPUNIT_ASSERT(!info->isScalar());
-    CPPUNIT_ASSERT_EQUAL(sizeof(int3Array), info->getMemSize());
+    CPPUNIT_ASSERT(!info.isScalar());
+    CPPUNIT_ASSERT_EQUAL(sizeof(int3Array), info.getMemSize());
     // Note: This is the file saved type. ColTypeInt will resolve to the generic variant
-    CPPUNIT_ASSERT(typeid(info->getType()) == typeid(ColTypeInt32));
-    CPPUNIT_ASSERT_EQUAL(3u, info->getNDims());
-    CPPUNIT_ASSERT_EQUAL(Dimensions(1, 1, 3), info->getDims());
-    CPPUNIT_ASSERT(!info->isVarSize());
-    info->read(&int3ArrayRead, sizeof(int3ArrayRead));
+    CPPUNIT_ASSERT(dynamic_cast<const ColTypeInt32*>(&info.getType()));
+    CPPUNIT_ASSERT_EQUAL(3u, info.getNDims());
+    CPPUNIT_ASSERT_EQUAL(Dimensions(1, 1, 3), info.getDims());
+    CPPUNIT_ASSERT(!info.isVarSize());
+    info.read(&int3ArrayRead, sizeof(int3ArrayRead));
     CPPUNIT_ASSERT(memcmp(int3Array3, int3ArrayRead, sizeof(int3ArrayRead)) == 0);
 
     info = dataCollector->readAttributeInfo(10, NULL, "dim");
-    CPPUNIT_ASSERT(info->isScalar());
-    CPPUNIT_ASSERT_EQUAL(sizeof(dim), info->getMemSize());
-    CPPUNIT_ASSERT(typeid(info->getType()) == typeid(ctDimArray));
-    CPPUNIT_ASSERT_EQUAL(1u, info->getNDims());
-    CPPUNIT_ASSERT_EQUAL(Dimensions(1, 1, 1), info->getDims());
-    CPPUNIT_ASSERT(!info->isVarSize());
-    info->read(&dimRead, dimRead.getSize());
+    CPPUNIT_ASSERT(info.isScalar());
+    CPPUNIT_ASSERT_EQUAL(sizeof(dim), info.getMemSize());
+    CPPUNIT_ASSERT(dynamic_cast<const ColTypeDimArray*>(&info.getType()));
+    CPPUNIT_ASSERT_EQUAL(1u, info.getNDims());
+    CPPUNIT_ASSERT_EQUAL(Dimensions(1, 1, 1), info.getDims());
+    CPPUNIT_ASSERT(!info.isVarSize());
+    info.read(&dimRead, dimRead.getSize());
     CPPUNIT_ASSERT_EQUAL(dim, dimRead);
 
     info = dataCollector->readAttributeInfo(10, NULL, "doubleArray");
-    CPPUNIT_ASSERT(!info->isScalar());
-    CPPUNIT_ASSERT_EQUAL(sizeof(doubleArray), info->getMemSize());
-    CPPUNIT_ASSERT(typeid(info->getType()) == typeid(ctDouble));
-    CPPUNIT_ASSERT_EQUAL(1u, info->getNDims());
-    CPPUNIT_ASSERT_EQUAL(Dimensions(7, 1, 1), info->getDims());
-    CPPUNIT_ASSERT(!info->isVarSize());
-    info->read(&doubleArrayRead, sizeof(doubleArrayRead));
+    CPPUNIT_ASSERT(!info.isScalar());
+    CPPUNIT_ASSERT_EQUAL(sizeof(doubleArray), info.getMemSize());
+    CPPUNIT_ASSERT(dynamic_cast<const ColTypeDouble*>(&info.getType()));
+    CPPUNIT_ASSERT_EQUAL(1u, info.getNDims());
+    CPPUNIT_ASSERT_EQUAL(Dimensions(7, 1, 1), info.getDims());
+    CPPUNIT_ASSERT(!info.isVarSize());
+    info.read(&doubleArrayRead, sizeof(doubleArrayRead));
     CPPUNIT_ASSERT(memcmp(doubleArray, doubleArrayRead, sizeof(doubleArrayRead)) == 0);
 
     info = dataCollector->readAttributeInfo(10, NULL, "strArray");
-    CPPUNIT_ASSERT(!info->isScalar());
-    CPPUNIT_ASSERT_EQUAL(sizeof(strArray), info->getMemSize());
-    CPPUNIT_ASSERT(typeid(info->getType()) == typeid(ColTypeString));
-    CPPUNIT_ASSERT_EQUAL(1u, info->getNDims());
-    CPPUNIT_ASSERT_EQUAL(Dimensions(3, 1, 1), info->getDims());
-    CPPUNIT_ASSERT(!info->isVarSize());
-    info->read(&strArrayRead, sizeof(strArrayRead));
+    CPPUNIT_ASSERT(!info.isScalar());
+    CPPUNIT_ASSERT_EQUAL(sizeof(strArray), info.getMemSize());
+    CPPUNIT_ASSERT(dynamic_cast<const ColTypeString*>(&info.getType()));
+    CPPUNIT_ASSERT_EQUAL(1u, info.getNDims());
+    CPPUNIT_ASSERT_EQUAL(Dimensions(3, 1, 1), info.getDims());
+    CPPUNIT_ASSERT(!info.isVarSize());
+    info.read(&strArrayRead, sizeof(strArrayRead));
     CPPUNIT_ASSERT(memcmp(strArray, strArrayRead, sizeof(strArrayRead)) == 0);
 
-    delete info;
     dataCollector->close();
 }

--- a/tests/AttributesTest.cpp
+++ b/tests/AttributesTest.cpp
@@ -29,10 +29,15 @@
 #include <cstring>
 #include <cppunit/TestAssert.h>
 
-std::ostream& operator<<(std::ostream& s, const splash::Dimensions& dim)
+namespace splash {
+
+// Declare this in namespace splash (required for ADL)
+std::ostream& operator<<(std::ostream& s, const Dimensions& dim)
 {
     return s << dim.toString();
 }
+
+}  // namespace splash
 
 CPPUNIT_TEST_SUITE_REGISTRATION(AttributesTest);
 
@@ -197,8 +202,9 @@ void AttributesTest::testAttributesMeta()
 
     dataCollector->open(TEST_FILE_META, attr);
 
-    int intVal = rand();
-    dataCollector->writeGlobalAttribute(ctInt, "intVal", &intVal);
+    const int intValGlob = rand();
+    const int intVal = rand();
+    dataCollector->writeGlobalAttribute(ctInt, "intValGlob", &intValGlob);
     dataCollector->writeAttribute(10, ctInt, NULL, "intVal", &intVal);
 
     /* variable length string, '\0' terminated */
@@ -211,8 +217,9 @@ void AttributesTest::testAttributesMeta()
     // Create a group
     dataCollector->write(10, ctInt, 1, Selection(Dimensions()), "group", &intVal);
 
-    char charVal = 'Y';
-    dataCollector->writeAttribute(10, ctInt, "group", "intVal", &intVal);
+    const int intValGroup = rand();
+    const char charVal = 'Y';
+    dataCollector->writeAttribute(10, ctInt, "group", "intValGroup", &intValGroup);
     dataCollector->writeAttribute(10, ctChar, "group", "charVal", &charVal);
 
     // Reopen in read mode
@@ -221,12 +228,15 @@ void AttributesTest::testAttributesMeta()
     dataCollector->open(TEST_FILE_META, attr);
 
     DCAttributeInfo* info = NULL;
-    info = dataCollector->readGlobalAttributeMeta(10, "intVal");
+    info = dataCollector->readGlobalAttributeMeta(10, "intValGlob");
     CPPUNIT_ASSERT(info->isScalar());
     CPPUNIT_ASSERT_EQUAL(sizeof(intVal), info->getMemSize());
     // Note: This is the file saved type. ColTypeInt will resolve to the generic variant
     CPPUNIT_ASSERT(typeid(info->getType()) == typeid(ColTypeInt32));
     CPPUNIT_ASSERT(!info->isVarSize());
+    int intValRead = 0;
+    info->read(ctInt, &intValRead);
+    CPPUNIT_ASSERT_EQUAL(intValGlob, intValRead);
 
     READ_ATTR_META(intVal, NULL);
     CPPUNIT_ASSERT(info->isScalar());
@@ -234,25 +244,39 @@ void AttributesTest::testAttributesMeta()
     // Note: This is the file saved type. ColTypeInt will resolve to the generic variant
     CPPUNIT_ASSERT(typeid(info->getType()) == typeid(ColTypeInt32));
     CPPUNIT_ASSERT(!info->isVarSize());
+    intValRead = 0;
+    info->read(ctInt, &intValRead);
+    CPPUNIT_ASSERT_EQUAL(intVal, intValRead);
 
     READ_ATTR_META(varLenStr, NULL);
     CPPUNIT_ASSERT(info->isScalar());
     CPPUNIT_ASSERT_EQUAL(sizeof(varLenStr), info->getMemSize());
     CPPUNIT_ASSERT(typeid(info->getType()) == typeid(ctString));
     CPPUNIT_ASSERT(info->isVarSize());
+    // Note: API returns a pointer to the string!
+    const char* varLenStrRead = NULL;
+    info->read(ctString, &varLenStrRead);
+    CPPUNIT_ASSERT(strcmp(varLenStr, varLenStrRead) == 0);
 
     READ_ATTR_META(fixedLenStr, NULL);
     CPPUNIT_ASSERT(info->isScalar());
     CPPUNIT_ASSERT_EQUAL(sizeof(fixedLenStr), info->getMemSize());
     CPPUNIT_ASSERT(typeid(info->getType()) == typeid(ctString4));
     CPPUNIT_ASSERT(!info->isVarSize());
+    // Note: API returns string data
+    std::vector<char> fixedLenStrRead(info->getMemSize());
+    info->read(ctString4, &fixedLenStrRead[0]);
+    CPPUNIT_ASSERT(strcmp(fixedLenStr, &fixedLenStrRead[0]) == 0);
 
-    READ_ATTR_META(intVal, "group");
+    READ_ATTR_META(intValGroup, "group");
     CPPUNIT_ASSERT(info->isScalar());
     CPPUNIT_ASSERT_EQUAL(sizeof(intVal), info->getMemSize());
     // Note: This is the file saved type. ColTypeInt will resolve to the generic variant
     CPPUNIT_ASSERT(typeid(info->getType()) == typeid(ColTypeInt32));
     CPPUNIT_ASSERT(!info->isVarSize());
+    int intValGroupRead = 0;
+    info->read(ctInt, &intValGroupRead);
+    CPPUNIT_ASSERT_EQUAL(intValGroup, intValGroupRead);
 
     READ_ATTR_META(charVal, "group");
     CPPUNIT_ASSERT(info->isScalar());
@@ -260,6 +284,9 @@ void AttributesTest::testAttributesMeta()
     // Note: Native char resolves to either Int8 or UInt8
     CPPUNIT_ASSERT(typeid(info->getType()) == typeid(ColTypeInt8) || typeid(info->getType()) == typeid(ColTypeUInt8));
     CPPUNIT_ASSERT(!info->isVarSize());
+    char charValRead = 0;
+    info->read(ctChar, &charValRead);
+    CPPUNIT_ASSERT_EQUAL(charVal, charValRead);
 
     delete info;
     dataCollector->close();
@@ -306,17 +333,20 @@ void AttributesTest::testArrayAttributesMeta()
 
     dataCollector->open(TEST_FILE_ARRAYMETA, attr);
 
-    const int int3Array[3] = { 17, 12, -99 };
-    double doubleArray[7] = {-3.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0};
-    Dimensions dim(104, 0, 2);
-    const int intVal= 42;
+    const int intVal  = rand();
+    const int intVal2 = rand();
+    const int int3Array[3] = { rand(), rand(), -rand() };
+    const int int3Array2[3] = { rand(), rand(), -rand() };
+    const int int3Array3[3] = { rand(), rand(), -rand() };
+    const double doubleArray[7] = {-(rand() * 10.)/RAND_MAX, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0};
+    const Dimensions dim(rand(), rand(), rand());
     const char strArray[6] = {"x\0y\0z"};
 
     dataCollector->writeAttribute(10, ctInt, NULL, "intVal", 1u, Dimensions(1, 1, 1), &intVal);
-    dataCollector->writeAttribute(10, ctInt, NULL, "intVal2", 3u, Dimensions(1, 1, 1), &intVal);
+    dataCollector->writeAttribute(10, ctInt, NULL, "intVal2", 3u, Dimensions(1, 1, 1), &intVal2);
     dataCollector->writeAttribute(10, ctInt3Array, NULL, "int3Array1", int3Array);
-    dataCollector->writeAttribute(10, ctInt, NULL, "int3Array2", 1u, Dimensions(3, 1, 1), int3Array);
-    dataCollector->writeAttribute(10, ctInt, NULL, "int3Array3", 3u, Dimensions(1, 1, 3), int3Array);
+    dataCollector->writeAttribute(10, ctInt, NULL, "int3Array2", 1u, Dimensions(3, 1, 1), int3Array2);
+    dataCollector->writeAttribute(10, ctInt, NULL, "int3Array3", 3u, Dimensions(1, 1, 3), int3Array3);
     dataCollector->writeAttribute(10, ctDimArray, NULL, "dim", dim.getPointer());
     dataCollector->writeAttribute(10, ctDouble, NULL, "doubleArray", 1u, Dimensions(7,1,1), doubleArray);
     dataCollector->writeAttribute(10, ColTypeString(1), NULL, "strArray", 1u, Dimensions(3,1,1), strArray);
@@ -326,6 +356,12 @@ void AttributesTest::testArrayAttributesMeta()
     attr.fileAccType = DataCollector::FAT_READ;
     dataCollector->open(TEST_FILE_ARRAYMETA, attr);
 
+    int intValRead  = 0;
+    int int3ArrayRead[3] = { 0,0,0 };
+    double doubleArrayRead[7] = {0, 0, 0, 0, 0, 0, 0};
+    Dimensions dimRead(0,0,0);
+    char strArrayRead[6] = "\0\0\0\0\0";
+
     DCAttributeInfo* info = NULL;
 
     READ_ATTR_META(intVal, NULL);
@@ -334,6 +370,8 @@ void AttributesTest::testArrayAttributesMeta()
     // Note: This is the file saved type. ColTypeInt will resolve to the generic variant
     CPPUNIT_ASSERT(typeid(info->getType()) == typeid(ColTypeInt32));
     CPPUNIT_ASSERT(!info->isVarSize());
+    info->read(&intValRead, sizeof(intValRead));
+    CPPUNIT_ASSERT_EQUAL(intVal, intValRead);
 
     READ_ATTR_META(intVal2, NULL);
     CPPUNIT_ASSERT(!info->isScalar());
@@ -343,12 +381,16 @@ void AttributesTest::testArrayAttributesMeta()
     CPPUNIT_ASSERT_EQUAL(3u, info->getNDims());
     CPPUNIT_ASSERT_EQUAL(Dimensions(1, 1, 1), info->getDims());
     CPPUNIT_ASSERT(!info->isVarSize());
+    info->read(&intValRead, sizeof(intValRead));
+    CPPUNIT_ASSERT_EQUAL(intVal2, intValRead);
 
     READ_ATTR_META(int3Array1, NULL);
     CPPUNIT_ASSERT(info->isScalar());
     CPPUNIT_ASSERT_EQUAL(sizeof(int3Array), info->getMemSize());
     CPPUNIT_ASSERT(typeid(info->getType()) == typeid(ctInt3Array));
     CPPUNIT_ASSERT(!info->isVarSize());
+    info->read(&int3ArrayRead, sizeof(int3ArrayRead));
+    CPPUNIT_ASSERT(memcmp(int3Array, int3ArrayRead, sizeof(int3ArrayRead)) == 0);
 
     READ_ATTR_META(int3Array2, NULL);
     CPPUNIT_ASSERT(!info->isScalar());
@@ -358,6 +400,8 @@ void AttributesTest::testArrayAttributesMeta()
     CPPUNIT_ASSERT_EQUAL(1u, info->getNDims());
     CPPUNIT_ASSERT_EQUAL(Dimensions(3, 1, 1), info->getDims());
     CPPUNIT_ASSERT(!info->isVarSize());
+    info->read(&int3ArrayRead, sizeof(int3ArrayRead));
+    CPPUNIT_ASSERT(memcmp(int3Array2, int3ArrayRead, sizeof(int3ArrayRead)) == 0);
 
     READ_ATTR_META(int3Array3, NULL);
     CPPUNIT_ASSERT(!info->isScalar());
@@ -367,6 +411,8 @@ void AttributesTest::testArrayAttributesMeta()
     CPPUNIT_ASSERT_EQUAL(3u, info->getNDims());
     CPPUNIT_ASSERT_EQUAL(Dimensions(1, 1, 3), info->getDims());
     CPPUNIT_ASSERT(!info->isVarSize());
+    info->read(&int3ArrayRead, sizeof(int3ArrayRead));
+    CPPUNIT_ASSERT(memcmp(int3Array3, int3ArrayRead, sizeof(int3ArrayRead)) == 0);
 
     READ_ATTR_META(dim, NULL);
     CPPUNIT_ASSERT(info->isScalar());
@@ -375,6 +421,8 @@ void AttributesTest::testArrayAttributesMeta()
     CPPUNIT_ASSERT_EQUAL(1u, info->getNDims());
     CPPUNIT_ASSERT_EQUAL(Dimensions(1, 1, 1), info->getDims());
     CPPUNIT_ASSERT(!info->isVarSize());
+    info->read(&dimRead, dimRead.getSize());
+    CPPUNIT_ASSERT_EQUAL(dim, dimRead);
 
     READ_ATTR_META(doubleArray, NULL);
     CPPUNIT_ASSERT(!info->isScalar());
@@ -383,6 +431,8 @@ void AttributesTest::testArrayAttributesMeta()
     CPPUNIT_ASSERT_EQUAL(1u, info->getNDims());
     CPPUNIT_ASSERT_EQUAL(Dimensions(7, 1, 1), info->getDims());
     CPPUNIT_ASSERT(!info->isVarSize());
+    info->read(&doubleArrayRead, sizeof(doubleArrayRead));
+    CPPUNIT_ASSERT(memcmp(doubleArray, doubleArrayRead, sizeof(doubleArrayRead)) == 0);
 
     READ_ATTR_META(strArray, NULL);
     CPPUNIT_ASSERT(!info->isScalar());
@@ -391,6 +441,8 @@ void AttributesTest::testArrayAttributesMeta()
     CPPUNIT_ASSERT_EQUAL(1u, info->getNDims());
     CPPUNIT_ASSERT_EQUAL(Dimensions(3, 1, 1), info->getDims());
     CPPUNIT_ASSERT(!info->isVarSize());
+    info->read(&strArrayRead, sizeof(strArrayRead));
+    CPPUNIT_ASSERT(memcmp(strArray, strArrayRead, sizeof(strArrayRead)) == 0);
 
     delete info;
     dataCollector->close();

--- a/tests/AttributesTest.cpp
+++ b/tests/AttributesTest.cpp
@@ -192,7 +192,7 @@ void AttributesTest::testDataAttributes()
 
 // Delete old info, read new info and check validity (reduce noise in test code)
 #define READ_ATTR_META(name, group) delete info; info = NULL;                           \
-                             info = dataCollector->readAttributeMeta(10, group, #name); \
+                             info = dataCollector->readAttributeInfo(10, group, #name); \
                              CPPUNIT_ASSERT(info);
 
 void AttributesTest::testAttributesMeta()
@@ -227,8 +227,8 @@ void AttributesTest::testAttributesMeta()
     attr.fileAccType = DataCollector::FAT_READ;
     dataCollector->open(TEST_FILE_META, attr);
 
-    DCAttributeInfo* info = NULL;
-    info = dataCollector->readGlobalAttributeMeta(10, "intValGlob");
+    AttributeInfo* info = NULL;
+    info = dataCollector->readGlobalAttributeInfo(10, "intValGlob");
     CPPUNIT_ASSERT(info->isScalar());
     CPPUNIT_ASSERT_EQUAL(sizeof(intVal), info->getMemSize());
     // Note: This is the file saved type. ColTypeInt will resolve to the generic variant
@@ -362,7 +362,7 @@ void AttributesTest::testArrayAttributesMeta()
     Dimensions dimRead(0,0,0);
     char strArrayRead[6] = "\0\0\0\0\0";
 
-    DCAttributeInfo* info = NULL;
+    AttributeInfo* info = NULL;
 
     READ_ATTR_META(intVal, NULL);
     CPPUNIT_ASSERT(info->isScalar());

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -93,6 +93,8 @@ INCLUDE_DIRECTORIES("${CMAKE_CURRENT_BINARY_DIR}/build_libsplash")
 
 #-------------------------------------------------------------------------------
 
+add_definitions(-Wno-deprecated-declarations)
+
 SET(LIBS splash_static m cppunit ${MPI_C_LIBRARIES} ${MPI_CXX_LIBRARIES} ${HDF5_LIBRARIES})
 IF(${vampir})
     SET(LIBS vt-hyb ${LIBS})

--- a/tests/Parallel_AttributesTest.cpp
+++ b/tests/Parallel_AttributesTest.cpp
@@ -264,6 +264,8 @@ void Parallel_AttributesTest::testAttributesMeta()
     char charValRead = 0;
     info.read(ctChar, &charValRead);
     CPPUNIT_ASSERT_EQUAL(charVal, charValRead);
+    
+    info.close();
 
     dataCollector->close();
     dataCollector->finalize();
@@ -428,6 +430,8 @@ void Parallel_AttributesTest::testArrayAttributesMeta()
     CPPUNIT_ASSERT(!info.isVarSize());
     info.read(&strArrayRead, sizeof(strArrayRead));
     CPPUNIT_ASSERT(memcmp(strArray, strArrayRead, sizeof(strArrayRead)) == 0);
+    
+    info.close();
 
     dataCollector->close();
     dataCollector->finalize();

--- a/tests/Parallel_AttributesTest.cpp
+++ b/tests/Parallel_AttributesTest.cpp
@@ -166,7 +166,7 @@ void Parallel_AttributesTest::testDataAttributes()
 }
 
 // Delete old info, read new info and check validity (reduce noise in test code)
-#define READ_ATTR_META(name, group) delete info; info = NULL;                                 \
+#define READ_ATTR_META(name, group) delete info; info = NULL;                           \
                              info = dataCollector->readAttributeMeta(10, group, #name); \
                              CPPUNIT_ASSERT(info);
 
@@ -209,34 +209,40 @@ void Parallel_AttributesTest::testAttributesMeta()
     CPPUNIT_ASSERT_EQUAL(sizeof(intVal), info->getMemSize());
     // Note: This is the file saved type. ColTypeInt will resolve to the generic variant
     CPPUNIT_ASSERT(typeid(info->getType()) == typeid(ColTypeInt32));
+    CPPUNIT_ASSERT(!info->isVarSize());
 
     READ_ATTR_META(intVal, NULL);
     CPPUNIT_ASSERT(info->isScalar());
     CPPUNIT_ASSERT_EQUAL(sizeof(intVal), info->getMemSize());
     // Note: This is the file saved type. ColTypeInt will resolve to the generic variant
     CPPUNIT_ASSERT(typeid(info->getType()) == typeid(ColTypeInt32));
+    CPPUNIT_ASSERT(!info->isVarSize());
 
     READ_ATTR_META(varLenStr, NULL);
     CPPUNIT_ASSERT(info->isScalar());
     CPPUNIT_ASSERT_EQUAL(sizeof(varLenStr), info->getMemSize());
     CPPUNIT_ASSERT(typeid(info->getType()) == typeid(ctString));
+    CPPUNIT_ASSERT(info->isVarSize());
 
     READ_ATTR_META(fixedLenStr, NULL);
     CPPUNIT_ASSERT(info->isScalar());
     CPPUNIT_ASSERT_EQUAL(sizeof(fixedLenStr), info->getMemSize());
     CPPUNIT_ASSERT(typeid(info->getType()) == typeid(ctString4));
+    CPPUNIT_ASSERT(!info->isVarSize());
 
     READ_ATTR_META(intVal, "group");
     CPPUNIT_ASSERT(info->isScalar());
     CPPUNIT_ASSERT_EQUAL(sizeof(intVal), info->getMemSize());
     // Note: This is the file saved type. ColTypeInt will resolve to the generic variant
     CPPUNIT_ASSERT(typeid(info->getType()) == typeid(ColTypeInt32));
+    CPPUNIT_ASSERT(!info->isVarSize());
 
     READ_ATTR_META(charVal, "group");
     CPPUNIT_ASSERT(info->isScalar());
     CPPUNIT_ASSERT_EQUAL(sizeof(charVal), info->getMemSize());
     // Note: Native char resolves to either Int8 or UInt8
     CPPUNIT_ASSERT(typeid(info->getType()) == typeid(ColTypeInt8) || typeid(info->getType()) == typeid(ColTypeUInt8));
+    CPPUNIT_ASSERT(!info->isVarSize());
 
     delete info;
     dataCollector->close();
@@ -298,6 +304,7 @@ void Parallel_AttributesTest::testArrayAttributesMeta()
     double doubleArray[7] = {-3.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0};
     Dimensions dim(104, 0, 2);
     const int intVal= 42;
+    const char strArray[6] = {"x\0y\0z"};
 
     dataCollector->writeAttribute(10, ctInt, NULL, "intVal", 1u, Dimensions(1, 1, 1), &intVal);
     dataCollector->writeAttribute(10, ctInt, NULL, "intVal2", 3u, Dimensions(1, 1, 1), &intVal);
@@ -306,6 +313,7 @@ void Parallel_AttributesTest::testArrayAttributesMeta()
     dataCollector->writeAttribute(10, ctInt, NULL, "int3Array3", 3u, Dimensions(1, 1, 3), int3Array);
     dataCollector->writeAttribute(10, ctDimArray, NULL, "dim", dim.getPointer());
     dataCollector->writeAttribute(10, ctDouble, NULL, "doubleArray", 1u, Dimensions(7,1,1), doubleArray);
+    dataCollector->writeAttribute(10, ColTypeString(1), NULL, "strArray", 1u, Dimensions(3,1,1), strArray);
 
     // Reopen in read mode
     dataCollector->close();
@@ -319,6 +327,7 @@ void Parallel_AttributesTest::testArrayAttributesMeta()
     CPPUNIT_ASSERT_EQUAL(sizeof(intVal), info->getMemSize());
     // Note: This is the file saved type. ColTypeInt will resolve to the generic variant
     CPPUNIT_ASSERT(typeid(info->getType()) == typeid(ColTypeInt32));
+    CPPUNIT_ASSERT(!info->isVarSize());
 
     READ_ATTR_META(intVal2, NULL);
     CPPUNIT_ASSERT(!info->isScalar());
@@ -327,11 +336,13 @@ void Parallel_AttributesTest::testArrayAttributesMeta()
     CPPUNIT_ASSERT(typeid(info->getType()) == typeid(ColTypeInt32));
     CPPUNIT_ASSERT_EQUAL(3u, info->getNDims());
     CPPUNIT_ASSERT_EQUAL(Dimensions(1, 1, 1), info->getDims());
+    CPPUNIT_ASSERT(!info->isVarSize());
 
     READ_ATTR_META(int3Array1, NULL);
     CPPUNIT_ASSERT(info->isScalar());
     CPPUNIT_ASSERT_EQUAL(sizeof(int3Array), info->getMemSize());
     CPPUNIT_ASSERT(typeid(info->getType()) == typeid(ctInt3Array));
+    CPPUNIT_ASSERT(!info->isVarSize());
 
     READ_ATTR_META(int3Array2, NULL);
     CPPUNIT_ASSERT(!info->isScalar());
@@ -340,6 +351,7 @@ void Parallel_AttributesTest::testArrayAttributesMeta()
     CPPUNIT_ASSERT(typeid(info->getType()) == typeid(ColTypeInt32));
     CPPUNIT_ASSERT_EQUAL(1u, info->getNDims());
     CPPUNIT_ASSERT_EQUAL(Dimensions(3, 1, 1), info->getDims());
+    CPPUNIT_ASSERT(!info->isVarSize());
 
     READ_ATTR_META(int3Array3, NULL);
     CPPUNIT_ASSERT(!info->isScalar());
@@ -348,6 +360,7 @@ void Parallel_AttributesTest::testArrayAttributesMeta()
     CPPUNIT_ASSERT(typeid(info->getType()) == typeid(ColTypeInt32));
     CPPUNIT_ASSERT_EQUAL(3u, info->getNDims());
     CPPUNIT_ASSERT_EQUAL(Dimensions(1, 1, 3), info->getDims());
+    CPPUNIT_ASSERT(!info->isVarSize());
 
     READ_ATTR_META(dim, NULL);
     CPPUNIT_ASSERT(info->isScalar());
@@ -355,6 +368,7 @@ void Parallel_AttributesTest::testArrayAttributesMeta()
     CPPUNIT_ASSERT(typeid(info->getType()) == typeid(ctDimArray));
     CPPUNIT_ASSERT_EQUAL(1u, info->getNDims());
     CPPUNIT_ASSERT_EQUAL(Dimensions(1, 1, 1), info->getDims());
+    CPPUNIT_ASSERT(!info->isVarSize());
 
     READ_ATTR_META(doubleArray, NULL);
     CPPUNIT_ASSERT(!info->isScalar());
@@ -362,6 +376,15 @@ void Parallel_AttributesTest::testArrayAttributesMeta()
     CPPUNIT_ASSERT(typeid(info->getType()) == typeid(ctDouble));
     CPPUNIT_ASSERT_EQUAL(1u, info->getNDims());
     CPPUNIT_ASSERT_EQUAL(Dimensions(7, 1, 1), info->getDims());
+    CPPUNIT_ASSERT(!info->isVarSize());
+
+    READ_ATTR_META(strArray, NULL);
+    CPPUNIT_ASSERT(!info->isScalar());
+    CPPUNIT_ASSERT_EQUAL(sizeof(strArray), info->getMemSize());
+    CPPUNIT_ASSERT(typeid(info->getType()) == typeid(ColTypeString));
+    CPPUNIT_ASSERT_EQUAL(1u, info->getNDims());
+    CPPUNIT_ASSERT_EQUAL(Dimensions(3, 1, 1), info->getDims());
+    CPPUNIT_ASSERT(!info->isVarSize());
 
     delete info;
     dataCollector->close();

--- a/tests/Parallel_AttributesTest.cpp
+++ b/tests/Parallel_AttributesTest.cpp
@@ -29,13 +29,20 @@
 #include <cstring>
 #include <cppunit/TestAssert.h>
 
+std::ostream& operator<<(std::ostream& s, const splash::Dimensions& dim)
+{
+    return s << dim.toString();
+}
+
 CPPUNIT_TEST_SUITE_REGISTRATION(Parallel_AttributesTest);
 
 using namespace splash;
 
 #define BUF_SIZE 32
 #define TEST_FILE "h5/attributesParallel"
+#define TEST_FILE_META "h5/attributesMetaParallel"
 #define TEST_FILE2 "h5/attributes_arrayParallel"
+#define TEST_FILE_ARRAYMETA "h5/attributes_arrayMetaParallel"
 
 #define MPI_SIZE_X 2
 #define MPI_SIZE_Y 2
@@ -153,8 +160,87 @@ void Parallel_AttributesTest::testDataAttributes()
     CPPUNIT_ASSERT(strcmp(string_read, string_attr) == 0);
     CPPUNIT_ASSERT(strcmp(string_read4, string_attr4) == 0);
 
-    dataCollector->finalize();
     dataCollector->close();
+    dataCollector->finalize();
+    delete dataCollector;
+}
+
+// Delete old info, read new info and check validity (reduce noise in test code)
+#define READ_ATTR_META(name, group) delete info; info = NULL;                                 \
+                             info = dataCollector->readAttributeMeta(10, group, #name); \
+                             CPPUNIT_ASSERT(info);
+
+void Parallel_AttributesTest::testAttributesMeta()
+{
+    DataCollector::FileCreationAttr attr;
+    DataCollector::initFileCreationAttr(attr);
+
+    IParallelDataCollector* dataCollector = new ParallelDataCollector(
+            MPI_COMM_WORLD, MPI_INFO_NULL, Dimensions(MPI_SIZE_X, MPI_SIZE_Y, 1), 1);
+
+    dataCollector->open(TEST_FILE_META, attr);
+
+    int intVal = rand();
+    dataCollector->writeGlobalAttribute(10, ctInt, "intVal", &intVal);
+    dataCollector->writeAttribute(10, ctInt, NULL, "intVal", &intVal);
+
+    /* variable length string, '\0' terminated */
+    const char *varLenStr = "My first c-string.";
+    dataCollector->writeAttribute(10, ctString, NULL, "varLenStr", &varLenStr);
+    /* fixed length string, '\0' terminated */
+    const char fixedLenStr[5] = {"ABCD"};
+    dataCollector->writeAttribute(10, ctString4, NULL, "fixedLenStr", &fixedLenStr);
+
+    // Create a group
+    dataCollector->write(10, ctInt, 1, Selection(Dimensions()), "group", &intVal);
+
+    char charVal = 'Y';
+    dataCollector->writeAttribute(10, ctInt, "group", "intVal", &intVal);
+    dataCollector->writeAttribute(10, ctChar, "group", "charVal", &charVal);
+
+    // Reopen in read mode
+    dataCollector->close();
+    attr.fileAccType = DataCollector::FAT_READ;
+    dataCollector->open(TEST_FILE_META, attr);
+
+    DCAttributeInfo* info = NULL;
+    info = dataCollector->readGlobalAttributeMeta(10, "intVal");
+    CPPUNIT_ASSERT(info->isScalar());
+    CPPUNIT_ASSERT_EQUAL(sizeof(intVal), info->getMemSize());
+    // Note: This is the file saved type. ColTypeInt will resolve to the generic variant
+    CPPUNIT_ASSERT(typeid(info->getType()) == typeid(ColTypeInt32));
+
+    READ_ATTR_META(intVal, NULL);
+    CPPUNIT_ASSERT(info->isScalar());
+    CPPUNIT_ASSERT_EQUAL(sizeof(intVal), info->getMemSize());
+    // Note: This is the file saved type. ColTypeInt will resolve to the generic variant
+    CPPUNIT_ASSERT(typeid(info->getType()) == typeid(ColTypeInt32));
+
+    READ_ATTR_META(varLenStr, NULL);
+    CPPUNIT_ASSERT(info->isScalar());
+    CPPUNIT_ASSERT_EQUAL(sizeof(varLenStr), info->getMemSize());
+    CPPUNIT_ASSERT(typeid(info->getType()) == typeid(ctString));
+
+    READ_ATTR_META(fixedLenStr, NULL);
+    CPPUNIT_ASSERT(info->isScalar());
+    CPPUNIT_ASSERT_EQUAL(sizeof(fixedLenStr), info->getMemSize());
+    CPPUNIT_ASSERT(typeid(info->getType()) == typeid(ctString4));
+
+    READ_ATTR_META(intVal, "group");
+    CPPUNIT_ASSERT(info->isScalar());
+    CPPUNIT_ASSERT_EQUAL(sizeof(intVal), info->getMemSize());
+    // Note: This is the file saved type. ColTypeInt will resolve to the generic variant
+    CPPUNIT_ASSERT(typeid(info->getType()) == typeid(ColTypeInt32));
+
+    READ_ATTR_META(charVal, "group");
+    CPPUNIT_ASSERT(info->isScalar());
+    CPPUNIT_ASSERT_EQUAL(sizeof(charVal), info->getMemSize());
+    // Note: Native char resolves to either Int8 or UInt8
+    CPPUNIT_ASSERT(typeid(info->getType()) == typeid(ColTypeInt8) || typeid(info->getType()) == typeid(ColTypeUInt8));
+
+    delete info;
+    dataCollector->close();
+    dataCollector->finalize();
     delete dataCollector;
 }
 
@@ -193,5 +279,92 @@ void Parallel_AttributesTest::testArrayTypes()
         CPPUNIT_ASSERT(dim_write[i] == dim_read[i]);
     }
 
+    dataCollector->close();
+    dataCollector->finalize();
+    delete dataCollector;
+}
+
+void Parallel_AttributesTest::testArrayAttributesMeta()
+{
+    DataCollector::FileCreationAttr attr;
+    DataCollector::initFileCreationAttr(attr);
+
+    IParallelDataCollector* dataCollector = new ParallelDataCollector(
+            MPI_COMM_WORLD, MPI_INFO_NULL, Dimensions(MPI_SIZE_X, MPI_SIZE_Y, 1), 1);
+
+    dataCollector->open(TEST_FILE_ARRAYMETA, attr);
+
+    const int int3Array[3] = { 17, 12, -99 };
+    double doubleArray[7] = {-3.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0};
+    Dimensions dim(104, 0, 2);
+    const int intVal= 42;
+
+    dataCollector->writeAttribute(10, ctInt, NULL, "intVal", 1u, Dimensions(1, 1, 1), &intVal);
+    dataCollector->writeAttribute(10, ctInt, NULL, "intVal2", 3u, Dimensions(1, 1, 1), &intVal);
+    dataCollector->writeAttribute(10, ctInt3Array, NULL, "int3Array1", int3Array);
+    dataCollector->writeAttribute(10, ctInt, NULL, "int3Array2", 1u, Dimensions(3, 1, 1), int3Array);
+    dataCollector->writeAttribute(10, ctInt, NULL, "int3Array3", 3u, Dimensions(1, 1, 3), int3Array);
+    dataCollector->writeAttribute(10, ctDimArray, NULL, "dim", dim.getPointer());
+    dataCollector->writeAttribute(10, ctDouble, NULL, "doubleArray", 1u, Dimensions(7,1,1), doubleArray);
+
+    // Reopen in read mode
+    dataCollector->close();
+    attr.fileAccType = DataCollector::FAT_READ;
+    dataCollector->open(TEST_FILE_ARRAYMETA, attr);
+
+    DCAttributeInfo* info = NULL;
+
+    READ_ATTR_META(intVal, NULL);
+    CPPUNIT_ASSERT(info->isScalar());
+    CPPUNIT_ASSERT_EQUAL(sizeof(intVal), info->getMemSize());
+    // Note: This is the file saved type. ColTypeInt will resolve to the generic variant
+    CPPUNIT_ASSERT(typeid(info->getType()) == typeid(ColTypeInt32));
+
+    READ_ATTR_META(intVal2, NULL);
+    CPPUNIT_ASSERT(!info->isScalar());
+    CPPUNIT_ASSERT_EQUAL(sizeof(intVal), info->getMemSize());
+    // Note: This is the file saved type. ColTypeInt will resolve to the generic variant
+    CPPUNIT_ASSERT(typeid(info->getType()) == typeid(ColTypeInt32));
+    CPPUNIT_ASSERT_EQUAL(3u, info->getNDims());
+    CPPUNIT_ASSERT_EQUAL(Dimensions(1, 1, 1), info->getDims());
+
+    READ_ATTR_META(int3Array1, NULL);
+    CPPUNIT_ASSERT(info->isScalar());
+    CPPUNIT_ASSERT_EQUAL(sizeof(int3Array), info->getMemSize());
+    CPPUNIT_ASSERT(typeid(info->getType()) == typeid(ctInt3Array));
+
+    READ_ATTR_META(int3Array2, NULL);
+    CPPUNIT_ASSERT(!info->isScalar());
+    CPPUNIT_ASSERT_EQUAL(sizeof(int3Array), info->getMemSize());
+    // Note: This is the file saved type. ColTypeInt will resolve to the generic variant
+    CPPUNIT_ASSERT(typeid(info->getType()) == typeid(ColTypeInt32));
+    CPPUNIT_ASSERT_EQUAL(1u, info->getNDims());
+    CPPUNIT_ASSERT_EQUAL(Dimensions(3, 1, 1), info->getDims());
+
+    READ_ATTR_META(int3Array3, NULL);
+    CPPUNIT_ASSERT(!info->isScalar());
+    CPPUNIT_ASSERT_EQUAL(sizeof(int3Array), info->getMemSize());
+    // Note: This is the file saved type. ColTypeInt will resolve to the generic variant
+    CPPUNIT_ASSERT(typeid(info->getType()) == typeid(ColTypeInt32));
+    CPPUNIT_ASSERT_EQUAL(3u, info->getNDims());
+    CPPUNIT_ASSERT_EQUAL(Dimensions(1, 1, 3), info->getDims());
+
+    READ_ATTR_META(dim, NULL);
+    CPPUNIT_ASSERT(info->isScalar());
+    CPPUNIT_ASSERT_EQUAL(sizeof(dim), info->getMemSize());
+    CPPUNIT_ASSERT(typeid(info->getType()) == typeid(ctDimArray));
+    CPPUNIT_ASSERT_EQUAL(1u, info->getNDims());
+    CPPUNIT_ASSERT_EQUAL(Dimensions(1, 1, 1), info->getDims());
+
+    READ_ATTR_META(doubleArray, NULL);
+    CPPUNIT_ASSERT(!info->isScalar());
+    CPPUNIT_ASSERT_EQUAL(sizeof(doubleArray), info->getMemSize());
+    CPPUNIT_ASSERT(typeid(info->getType()) == typeid(ctDouble));
+    CPPUNIT_ASSERT_EQUAL(1u, info->getNDims());
+    CPPUNIT_ASSERT_EQUAL(Dimensions(7, 1, 1), info->getDims());
+
+    delete info;
+    dataCollector->close();
+    dataCollector->finalize();
     delete dataCollector;
 }

--- a/tests/Parallel_AttributesTest.cpp
+++ b/tests/Parallel_AttributesTest.cpp
@@ -170,11 +170,6 @@ void Parallel_AttributesTest::testDataAttributes()
     delete dataCollector;
 }
 
-// Delete old info, read new info and check validity (reduce noise in test code)
-#define READ_ATTR_META(name, group) delete info; info = NULL;                           \
-                             info = dataCollector->readAttributeInfo(10, group, #name); \
-                             CPPUNIT_ASSERT(info);
-
 void Parallel_AttributesTest::testAttributesMeta()
 {
     DataCollector::FileCreationAttr attr;
@@ -210,8 +205,7 @@ void Parallel_AttributesTest::testAttributesMeta()
     attr.fileAccType = DataCollector::FAT_READ;
     dataCollector->open(TEST_FILE_META, attr);
 
-    AttributeInfo* info = NULL;
-    info = dataCollector->readGlobalAttributeInfo(10, "intValGlob");
+    AttributeInfo info = dataCollector->readGlobalAttributeInfo(10, "intValGlob");
     CPPUNIT_ASSERT(info->isScalar());
     CPPUNIT_ASSERT_EQUAL(sizeof(intVal), info->getMemSize());
     // Note: This is the file saved type. ColTypeInt will resolve to the generic variant
@@ -221,7 +215,7 @@ void Parallel_AttributesTest::testAttributesMeta()
     info->read(ctInt, &intValRead);
     CPPUNIT_ASSERT_EQUAL(intValGlob, intValRead);
 
-    READ_ATTR_META(intVal, NULL);
+    info = dataCollector->readAttributeInfo(10, NULL, "intVal");
     CPPUNIT_ASSERT(info->isScalar());
     CPPUNIT_ASSERT_EQUAL(sizeof(intVal), info->getMemSize());
     // Note: This is the file saved type. ColTypeInt will resolve to the generic variant
@@ -231,7 +225,7 @@ void Parallel_AttributesTest::testAttributesMeta()
     info->read(ctInt, &intValRead);
     CPPUNIT_ASSERT_EQUAL(intVal, intValRead);
 
-    READ_ATTR_META(varLenStr, NULL);
+    info = dataCollector->readAttributeInfo(10, NULL, "varLenStr");
     CPPUNIT_ASSERT(info->isScalar());
     CPPUNIT_ASSERT_EQUAL(sizeof(varLenStr), info->getMemSize());
     CPPUNIT_ASSERT(typeid(info->getType()) == typeid(ctString));
@@ -241,7 +235,7 @@ void Parallel_AttributesTest::testAttributesMeta()
     info->read(ctString, &varLenStrRead);
     CPPUNIT_ASSERT(strcmp(varLenStr, varLenStrRead) == 0);
 
-    READ_ATTR_META(fixedLenStr, NULL);
+    info = dataCollector->readAttributeInfo(10, NULL, "fixedLenStr");
     CPPUNIT_ASSERT(info->isScalar());
     CPPUNIT_ASSERT_EQUAL(sizeof(fixedLenStr), info->getMemSize());
     CPPUNIT_ASSERT(typeid(info->getType()) == typeid(ctString4));
@@ -251,7 +245,7 @@ void Parallel_AttributesTest::testAttributesMeta()
     info->read(ctString4, &fixedLenStrRead[0]);
     CPPUNIT_ASSERT(strcmp(fixedLenStr, &fixedLenStrRead[0]) == 0);
 
-    READ_ATTR_META(intValGroup, "group");
+    info = dataCollector->readAttributeInfo(10, "group", "intValGroup");
     CPPUNIT_ASSERT(info->isScalar());
     CPPUNIT_ASSERT_EQUAL(sizeof(intVal), info->getMemSize());
     // Note: This is the file saved type. ColTypeInt will resolve to the generic variant
@@ -261,7 +255,7 @@ void Parallel_AttributesTest::testAttributesMeta()
     info->read(ctInt, &intValGroupRead);
     CPPUNIT_ASSERT_EQUAL(intValGroup, intValGroupRead);
 
-    READ_ATTR_META(charVal, "group");
+    info = dataCollector->readAttributeInfo(10, "group", "charVal");
     CPPUNIT_ASSERT(info->isScalar());
     CPPUNIT_ASSERT_EQUAL(sizeof(charVal), info->getMemSize());
     // Note: Native char resolves to either Int8 or UInt8
@@ -356,9 +350,7 @@ void Parallel_AttributesTest::testArrayAttributesMeta()
     Dimensions dimRead(0,0,0);
     char strArrayRead[6] = "\0\0\0\0\0";
 
-    AttributeInfo* info = NULL;
-
-    READ_ATTR_META(intVal, NULL);
+    AttributeInfo info = dataCollector->readAttributeInfo(10, NULL, "intVal");
     CPPUNIT_ASSERT(info->isScalar());
     CPPUNIT_ASSERT_EQUAL(sizeof(intVal), info->getMemSize());
     // Note: This is the file saved type. ColTypeInt will resolve to the generic variant
@@ -367,7 +359,7 @@ void Parallel_AttributesTest::testArrayAttributesMeta()
     info->read(&intValRead, sizeof(intValRead));
     CPPUNIT_ASSERT_EQUAL(intVal, intValRead);
 
-    READ_ATTR_META(intVal2, NULL);
+    info = dataCollector->readAttributeInfo(10, NULL, "intVal2");
     CPPUNIT_ASSERT(!info->isScalar());
     CPPUNIT_ASSERT_EQUAL(sizeof(intVal), info->getMemSize());
     // Note: This is the file saved type. ColTypeInt will resolve to the generic variant
@@ -378,7 +370,7 @@ void Parallel_AttributesTest::testArrayAttributesMeta()
     info->read(&intValRead, sizeof(intValRead));
     CPPUNIT_ASSERT_EQUAL(intVal2, intValRead);
 
-    READ_ATTR_META(int3Array1, NULL);
+    info = dataCollector->readAttributeInfo(10, NULL, "int3Array1");
     CPPUNIT_ASSERT(info->isScalar());
     CPPUNIT_ASSERT_EQUAL(sizeof(int3Array), info->getMemSize());
     CPPUNIT_ASSERT(typeid(info->getType()) == typeid(ctInt3Array));
@@ -386,7 +378,7 @@ void Parallel_AttributesTest::testArrayAttributesMeta()
     info->read(&int3ArrayRead, sizeof(int3ArrayRead));
     CPPUNIT_ASSERT(memcmp(int3Array, int3ArrayRead, sizeof(int3ArrayRead)) == 0);
 
-    READ_ATTR_META(int3Array2, NULL);
+    info = dataCollector->readAttributeInfo(10, NULL, "int3Array2");
     CPPUNIT_ASSERT(!info->isScalar());
     CPPUNIT_ASSERT_EQUAL(sizeof(int3Array), info->getMemSize());
     // Note: This is the file saved type. ColTypeInt will resolve to the generic variant
@@ -397,7 +389,7 @@ void Parallel_AttributesTest::testArrayAttributesMeta()
     info->read(&int3ArrayRead, sizeof(int3ArrayRead));
     CPPUNIT_ASSERT(memcmp(int3Array2, int3ArrayRead, sizeof(int3ArrayRead)) == 0);
 
-    READ_ATTR_META(int3Array3, NULL);
+    info = dataCollector->readAttributeInfo(10, NULL, "int3Array3");
     CPPUNIT_ASSERT(!info->isScalar());
     CPPUNIT_ASSERT_EQUAL(sizeof(int3Array), info->getMemSize());
     // Note: This is the file saved type. ColTypeInt will resolve to the generic variant
@@ -408,7 +400,7 @@ void Parallel_AttributesTest::testArrayAttributesMeta()
     info->read(&int3ArrayRead, sizeof(int3ArrayRead));
     CPPUNIT_ASSERT(memcmp(int3Array3, int3ArrayRead, sizeof(int3ArrayRead)) == 0);
 
-    READ_ATTR_META(dim, NULL);
+    info = dataCollector->readAttributeInfo(10, NULL, "dim");
     CPPUNIT_ASSERT(info->isScalar());
     CPPUNIT_ASSERT_EQUAL(sizeof(dim), info->getMemSize());
     CPPUNIT_ASSERT(typeid(info->getType()) == typeid(ctDimArray));
@@ -418,7 +410,7 @@ void Parallel_AttributesTest::testArrayAttributesMeta()
     info->read(&dimRead, dimRead.getSize());
     CPPUNIT_ASSERT_EQUAL(dim, dimRead);
 
-    READ_ATTR_META(doubleArray, NULL);
+    info = dataCollector->readAttributeInfo(10, NULL, "doubleArray");
     CPPUNIT_ASSERT(!info->isScalar());
     CPPUNIT_ASSERT_EQUAL(sizeof(doubleArray), info->getMemSize());
     CPPUNIT_ASSERT(typeid(info->getType()) == typeid(ctDouble));
@@ -428,7 +420,7 @@ void Parallel_AttributesTest::testArrayAttributesMeta()
     info->read(&doubleArrayRead, sizeof(doubleArrayRead));
     CPPUNIT_ASSERT(memcmp(doubleArray, doubleArrayRead, sizeof(doubleArrayRead)) == 0);
 
-    READ_ATTR_META(strArray, NULL);
+    info = dataCollector->readAttributeInfo(10, NULL, "strArray");
     CPPUNIT_ASSERT(!info->isScalar());
     CPPUNIT_ASSERT_EQUAL(sizeof(strArray), info->getMemSize());
     CPPUNIT_ASSERT(typeid(info->getType()) == typeid(ColTypeString));

--- a/tests/Parallel_AttributesTest.cpp
+++ b/tests/Parallel_AttributesTest.cpp
@@ -172,7 +172,7 @@ void Parallel_AttributesTest::testDataAttributes()
 
 // Delete old info, read new info and check validity (reduce noise in test code)
 #define READ_ATTR_META(name, group) delete info; info = NULL;                           \
-                             info = dataCollector->readAttributeMeta(10, group, #name); \
+                             info = dataCollector->readAttributeInfo(10, group, #name); \
                              CPPUNIT_ASSERT(info);
 
 void Parallel_AttributesTest::testAttributesMeta()
@@ -210,8 +210,8 @@ void Parallel_AttributesTest::testAttributesMeta()
     attr.fileAccType = DataCollector::FAT_READ;
     dataCollector->open(TEST_FILE_META, attr);
 
-    DCAttributeInfo* info = NULL;
-    info = dataCollector->readGlobalAttributeMeta(10, "intValGlob");
+    AttributeInfo* info = NULL;
+    info = dataCollector->readGlobalAttributeInfo(10, "intValGlob");
     CPPUNIT_ASSERT(info->isScalar());
     CPPUNIT_ASSERT_EQUAL(sizeof(intVal), info->getMemSize());
     // Note: This is the file saved type. ColTypeInt will resolve to the generic variant
@@ -356,7 +356,7 @@ void Parallel_AttributesTest::testArrayAttributesMeta()
     Dimensions dimRead(0,0,0);
     char strArrayRead[6] = "\0\0\0\0\0";
 
-    DCAttributeInfo* info = NULL;
+    AttributeInfo* info = NULL;
 
     READ_ATTR_META(intVal, NULL);
     CPPUNIT_ASSERT(info->isScalar());

--- a/tests/Parallel_AttributesTest.cpp
+++ b/tests/Parallel_AttributesTest.cpp
@@ -206,66 +206,65 @@ void Parallel_AttributesTest::testAttributesMeta()
     dataCollector->open(TEST_FILE_META, attr);
 
     AttributeInfo info = dataCollector->readGlobalAttributeInfo(10, "intValGlob");
-    CPPUNIT_ASSERT(info->isScalar());
-    CPPUNIT_ASSERT_EQUAL(sizeof(intVal), info->getMemSize());
+    CPPUNIT_ASSERT(info.isScalar());
+    CPPUNIT_ASSERT_EQUAL(sizeof(intVal), info.getMemSize());
     // Note: This is the file saved type. ColTypeInt will resolve to the generic variant
-    CPPUNIT_ASSERT(typeid(info->getType()) == typeid(ColTypeInt32));
-    CPPUNIT_ASSERT(!info->isVarSize());
+    CPPUNIT_ASSERT(dynamic_cast<const ColTypeInt32*>(&info.getType()));
+    CPPUNIT_ASSERT(!info.isVarSize());
     int intValRead = 0;
-    info->read(ctInt, &intValRead);
+    info.read(ctInt, &intValRead);
     CPPUNIT_ASSERT_EQUAL(intValGlob, intValRead);
 
     info = dataCollector->readAttributeInfo(10, NULL, "intVal");
-    CPPUNIT_ASSERT(info->isScalar());
-    CPPUNIT_ASSERT_EQUAL(sizeof(intVal), info->getMemSize());
+    CPPUNIT_ASSERT(info.isScalar());
+    CPPUNIT_ASSERT_EQUAL(sizeof(intVal), info.getMemSize());
     // Note: This is the file saved type. ColTypeInt will resolve to the generic variant
-    CPPUNIT_ASSERT(typeid(info->getType()) == typeid(ColTypeInt32));
-    CPPUNIT_ASSERT(!info->isVarSize());
+    CPPUNIT_ASSERT(dynamic_cast<const ColTypeInt32*>(&info.getType()));
+    CPPUNIT_ASSERT(!info.isVarSize());
     intValRead = 0;
-    info->read(ctInt, &intValRead);
+    info.read(ctInt, &intValRead);
     CPPUNIT_ASSERT_EQUAL(intVal, intValRead);
 
     info = dataCollector->readAttributeInfo(10, NULL, "varLenStr");
-    CPPUNIT_ASSERT(info->isScalar());
-    CPPUNIT_ASSERT_EQUAL(sizeof(varLenStr), info->getMemSize());
-    CPPUNIT_ASSERT(typeid(info->getType()) == typeid(ctString));
-    CPPUNIT_ASSERT(info->isVarSize());
+    CPPUNIT_ASSERT(info.isScalar());
+    CPPUNIT_ASSERT_EQUAL(sizeof(varLenStr), info.getMemSize());
+    CPPUNIT_ASSERT(dynamic_cast<const ColTypeString*>(&info.getType()));
+    CPPUNIT_ASSERT(info.isVarSize());
     // Note: API returns a pointer to the string!
     const char* varLenStrRead = NULL;
-    info->read(ctString, &varLenStrRead);
+    info.read(ctString, &varLenStrRead);
     CPPUNIT_ASSERT(strcmp(varLenStr, varLenStrRead) == 0);
 
     info = dataCollector->readAttributeInfo(10, NULL, "fixedLenStr");
-    CPPUNIT_ASSERT(info->isScalar());
-    CPPUNIT_ASSERT_EQUAL(sizeof(fixedLenStr), info->getMemSize());
-    CPPUNIT_ASSERT(typeid(info->getType()) == typeid(ctString4));
-    CPPUNIT_ASSERT(!info->isVarSize());
+    CPPUNIT_ASSERT(info.isScalar());
+    CPPUNIT_ASSERT_EQUAL(sizeof(fixedLenStr), info.getMemSize());
+    CPPUNIT_ASSERT(dynamic_cast<const ColTypeString*>(&info.getType()));
+    CPPUNIT_ASSERT(!info.isVarSize());
     // Note: API returns string data
-    std::vector<char> fixedLenStrRead(info->getMemSize());
-    info->read(ctString4, &fixedLenStrRead[0]);
+    std::vector<char> fixedLenStrRead(info.getMemSize());
+    info.read(ctString4, &fixedLenStrRead[0]);
     CPPUNIT_ASSERT(strcmp(fixedLenStr, &fixedLenStrRead[0]) == 0);
 
     info = dataCollector->readAttributeInfo(10, "group", "intValGroup");
-    CPPUNIT_ASSERT(info->isScalar());
-    CPPUNIT_ASSERT_EQUAL(sizeof(intVal), info->getMemSize());
+    CPPUNIT_ASSERT(info.isScalar());
+    CPPUNIT_ASSERT_EQUAL(sizeof(intVal), info.getMemSize());
     // Note: This is the file saved type. ColTypeInt will resolve to the generic variant
-    CPPUNIT_ASSERT(typeid(info->getType()) == typeid(ColTypeInt32));
-    CPPUNIT_ASSERT(!info->isVarSize());
+    CPPUNIT_ASSERT(dynamic_cast<const ColTypeInt32*>(&info.getType()));
+    CPPUNIT_ASSERT(!info.isVarSize());
     int intValGroupRead = 0;
-    info->read(ctInt, &intValGroupRead);
+    info.read(ctInt, &intValGroupRead);
     CPPUNIT_ASSERT_EQUAL(intValGroup, intValGroupRead);
 
     info = dataCollector->readAttributeInfo(10, "group", "charVal");
-    CPPUNIT_ASSERT(info->isScalar());
-    CPPUNIT_ASSERT_EQUAL(sizeof(charVal), info->getMemSize());
+    CPPUNIT_ASSERT(info.isScalar());
+    CPPUNIT_ASSERT_EQUAL(sizeof(charVal), info.getMemSize());
     // Note: Native char resolves to either Int8 or UInt8
-    CPPUNIT_ASSERT(typeid(info->getType()) == typeid(ColTypeInt8) || typeid(info->getType()) == typeid(ColTypeUInt8));
-    CPPUNIT_ASSERT(!info->isVarSize());
+    CPPUNIT_ASSERT(dynamic_cast<const ColTypeInt8*>(&info.getType()) || dynamic_cast<const ColTypeUInt8*>(&info.getType()));
+    CPPUNIT_ASSERT(!info.isVarSize());
     char charValRead = 0;
-    info->read(ctChar, &charValRead);
+    info.read(ctChar, &charValRead);
     CPPUNIT_ASSERT_EQUAL(charVal, charValRead);
 
-    delete info;
     dataCollector->close();
     dataCollector->finalize();
     delete dataCollector;
@@ -351,86 +350,85 @@ void Parallel_AttributesTest::testArrayAttributesMeta()
     char strArrayRead[6] = "\0\0\0\0\0";
 
     AttributeInfo info = dataCollector->readAttributeInfo(10, NULL, "intVal");
-    CPPUNIT_ASSERT(info->isScalar());
-    CPPUNIT_ASSERT_EQUAL(sizeof(intVal), info->getMemSize());
+    CPPUNIT_ASSERT(info.isScalar());
+    CPPUNIT_ASSERT_EQUAL(sizeof(intVal), info.getMemSize());
     // Note: This is the file saved type. ColTypeInt will resolve to the generic variant
-    CPPUNIT_ASSERT(typeid(info->getType()) == typeid(ColTypeInt32));
-    CPPUNIT_ASSERT(!info->isVarSize());
-    info->read(&intValRead, sizeof(intValRead));
+    CPPUNIT_ASSERT(dynamic_cast<const ColTypeInt32*>(&info.getType()));
+    CPPUNIT_ASSERT(!info.isVarSize());
+    info.read(&intValRead, sizeof(intValRead));
     CPPUNIT_ASSERT_EQUAL(intVal, intValRead);
 
     info = dataCollector->readAttributeInfo(10, NULL, "intVal2");
-    CPPUNIT_ASSERT(!info->isScalar());
-    CPPUNIT_ASSERT_EQUAL(sizeof(intVal), info->getMemSize());
+    CPPUNIT_ASSERT(!info.isScalar());
+    CPPUNIT_ASSERT_EQUAL(sizeof(intVal), info.getMemSize());
     // Note: This is the file saved type. ColTypeInt will resolve to the generic variant
-    CPPUNIT_ASSERT(typeid(info->getType()) == typeid(ColTypeInt32));
-    CPPUNIT_ASSERT_EQUAL(3u, info->getNDims());
-    CPPUNIT_ASSERT_EQUAL(Dimensions(1, 1, 1), info->getDims());
-    CPPUNIT_ASSERT(!info->isVarSize());
-    info->read(&intValRead, sizeof(intValRead));
+    CPPUNIT_ASSERT(dynamic_cast<const ColTypeInt32*>(&info.getType()));
+    CPPUNIT_ASSERT_EQUAL(3u, info.getNDims());
+    CPPUNIT_ASSERT_EQUAL(Dimensions(1, 1, 1), info.getDims());
+    CPPUNIT_ASSERT(!info.isVarSize());
+    info.read(&intValRead, sizeof(intValRead));
     CPPUNIT_ASSERT_EQUAL(intVal2, intValRead);
 
     info = dataCollector->readAttributeInfo(10, NULL, "int3Array1");
-    CPPUNIT_ASSERT(info->isScalar());
-    CPPUNIT_ASSERT_EQUAL(sizeof(int3Array), info->getMemSize());
-    CPPUNIT_ASSERT(typeid(info->getType()) == typeid(ctInt3Array));
-    CPPUNIT_ASSERT(!info->isVarSize());
-    info->read(&int3ArrayRead, sizeof(int3ArrayRead));
+    CPPUNIT_ASSERT(info.isScalar());
+    CPPUNIT_ASSERT_EQUAL(sizeof(int3Array), info.getMemSize());
+    CPPUNIT_ASSERT(dynamic_cast<const ColTypeInt3Array*>(&info.getType()));
+    CPPUNIT_ASSERT(!info.isVarSize());
+    info.read(&int3ArrayRead, sizeof(int3ArrayRead));
     CPPUNIT_ASSERT(memcmp(int3Array, int3ArrayRead, sizeof(int3ArrayRead)) == 0);
 
     info = dataCollector->readAttributeInfo(10, NULL, "int3Array2");
-    CPPUNIT_ASSERT(!info->isScalar());
-    CPPUNIT_ASSERT_EQUAL(sizeof(int3Array), info->getMemSize());
+    CPPUNIT_ASSERT(!info.isScalar());
+    CPPUNIT_ASSERT_EQUAL(sizeof(int3Array), info.getMemSize());
     // Note: This is the file saved type. ColTypeInt will resolve to the generic variant
-    CPPUNIT_ASSERT(typeid(info->getType()) == typeid(ColTypeInt32));
-    CPPUNIT_ASSERT_EQUAL(1u, info->getNDims());
-    CPPUNIT_ASSERT_EQUAL(Dimensions(3, 1, 1), info->getDims());
-    CPPUNIT_ASSERT(!info->isVarSize());
-    info->read(&int3ArrayRead, sizeof(int3ArrayRead));
+    CPPUNIT_ASSERT(dynamic_cast<const ColTypeInt32*>(&info.getType()));
+    CPPUNIT_ASSERT_EQUAL(1u, info.getNDims());
+    CPPUNIT_ASSERT_EQUAL(Dimensions(3, 1, 1), info.getDims());
+    CPPUNIT_ASSERT(!info.isVarSize());
+    info.read(&int3ArrayRead, sizeof(int3ArrayRead));
     CPPUNIT_ASSERT(memcmp(int3Array2, int3ArrayRead, sizeof(int3ArrayRead)) == 0);
 
     info = dataCollector->readAttributeInfo(10, NULL, "int3Array3");
-    CPPUNIT_ASSERT(!info->isScalar());
-    CPPUNIT_ASSERT_EQUAL(sizeof(int3Array), info->getMemSize());
+    CPPUNIT_ASSERT(!info.isScalar());
+    CPPUNIT_ASSERT_EQUAL(sizeof(int3Array), info.getMemSize());
     // Note: This is the file saved type. ColTypeInt will resolve to the generic variant
-    CPPUNIT_ASSERT(typeid(info->getType()) == typeid(ColTypeInt32));
-    CPPUNIT_ASSERT_EQUAL(3u, info->getNDims());
-    CPPUNIT_ASSERT_EQUAL(Dimensions(1, 1, 3), info->getDims());
-    CPPUNIT_ASSERT(!info->isVarSize());
-    info->read(&int3ArrayRead, sizeof(int3ArrayRead));
+    CPPUNIT_ASSERT(dynamic_cast<const ColTypeInt32*>(&info.getType()));
+    CPPUNIT_ASSERT_EQUAL(3u, info.getNDims());
+    CPPUNIT_ASSERT_EQUAL(Dimensions(1, 1, 3), info.getDims());
+    CPPUNIT_ASSERT(!info.isVarSize());
+    info.read(&int3ArrayRead, sizeof(int3ArrayRead));
     CPPUNIT_ASSERT(memcmp(int3Array3, int3ArrayRead, sizeof(int3ArrayRead)) == 0);
 
     info = dataCollector->readAttributeInfo(10, NULL, "dim");
-    CPPUNIT_ASSERT(info->isScalar());
-    CPPUNIT_ASSERT_EQUAL(sizeof(dim), info->getMemSize());
-    CPPUNIT_ASSERT(typeid(info->getType()) == typeid(ctDimArray));
-    CPPUNIT_ASSERT_EQUAL(1u, info->getNDims());
-    CPPUNIT_ASSERT_EQUAL(Dimensions(1, 1, 1), info->getDims());
-    CPPUNIT_ASSERT(!info->isVarSize());
-    info->read(&dimRead, dimRead.getSize());
+    CPPUNIT_ASSERT(info.isScalar());
+    CPPUNIT_ASSERT_EQUAL(sizeof(dim), info.getMemSize());
+    CPPUNIT_ASSERT(dynamic_cast<const ColTypeDimArray*>(&info.getType()));
+    CPPUNIT_ASSERT_EQUAL(1u, info.getNDims());
+    CPPUNIT_ASSERT_EQUAL(Dimensions(1, 1, 1), info.getDims());
+    CPPUNIT_ASSERT(!info.isVarSize());
+    info.read(&dimRead, dimRead.getSize());
     CPPUNIT_ASSERT_EQUAL(dim, dimRead);
 
     info = dataCollector->readAttributeInfo(10, NULL, "doubleArray");
-    CPPUNIT_ASSERT(!info->isScalar());
-    CPPUNIT_ASSERT_EQUAL(sizeof(doubleArray), info->getMemSize());
-    CPPUNIT_ASSERT(typeid(info->getType()) == typeid(ctDouble));
-    CPPUNIT_ASSERT_EQUAL(1u, info->getNDims());
-    CPPUNIT_ASSERT_EQUAL(Dimensions(7, 1, 1), info->getDims());
-    CPPUNIT_ASSERT(!info->isVarSize());
-    info->read(&doubleArrayRead, sizeof(doubleArrayRead));
+    CPPUNIT_ASSERT(!info.isScalar());
+    CPPUNIT_ASSERT_EQUAL(sizeof(doubleArray), info.getMemSize());
+    CPPUNIT_ASSERT(dynamic_cast<const ColTypeDouble*>(&info.getType()));
+    CPPUNIT_ASSERT_EQUAL(1u, info.getNDims());
+    CPPUNIT_ASSERT_EQUAL(Dimensions(7, 1, 1), info.getDims());
+    CPPUNIT_ASSERT(!info.isVarSize());
+    info.read(&doubleArrayRead, sizeof(doubleArrayRead));
     CPPUNIT_ASSERT(memcmp(doubleArray, doubleArrayRead, sizeof(doubleArrayRead)) == 0);
 
     info = dataCollector->readAttributeInfo(10, NULL, "strArray");
-    CPPUNIT_ASSERT(!info->isScalar());
-    CPPUNIT_ASSERT_EQUAL(sizeof(strArray), info->getMemSize());
-    CPPUNIT_ASSERT(typeid(info->getType()) == typeid(ColTypeString));
-    CPPUNIT_ASSERT_EQUAL(1u, info->getNDims());
-    CPPUNIT_ASSERT_EQUAL(Dimensions(3, 1, 1), info->getDims());
-    CPPUNIT_ASSERT(!info->isVarSize());
-    info->read(&strArrayRead, sizeof(strArrayRead));
+    CPPUNIT_ASSERT(!info.isScalar());
+    CPPUNIT_ASSERT_EQUAL(sizeof(strArray), info.getMemSize());
+    CPPUNIT_ASSERT(dynamic_cast<const ColTypeString*>(&info.getType()));
+    CPPUNIT_ASSERT_EQUAL(1u, info.getNDims());
+    CPPUNIT_ASSERT_EQUAL(Dimensions(3, 1, 1), info.getDims());
+    CPPUNIT_ASSERT(!info.isVarSize());
+    info.read(&strArrayRead, sizeof(strArrayRead));
     CPPUNIT_ASSERT(memcmp(strArray, strArrayRead, sizeof(strArrayRead)) == 0);
 
-    delete info;
     dataCollector->close();
     dataCollector->finalize();
     delete dataCollector;

--- a/tests/include/AttributesTest.h
+++ b/tests/include/AttributesTest.h
@@ -34,7 +34,9 @@ class AttributesTest  : public CPPUNIT_NS::TestFixture
     CPPUNIT_TEST_SUITE(AttributesTest);
 
     CPPUNIT_TEST(testDataAttributes);
+    CPPUNIT_TEST(testAttributesMeta);
     CPPUNIT_TEST(testArrayTypes);
+    CPPUNIT_TEST(testArrayAttributesMeta);
 
     CPPUNIT_TEST_SUITE_END();
 public:
@@ -43,6 +45,8 @@ public:
 private:
     void testDataAttributes();
     void testArrayTypes();
+    void testAttributesMeta();
+    void testArrayAttributesMeta();
 
     ColTypeChar ctChar;
     ColTypeDouble ctDouble;

--- a/tests/include/Parallel_AttributesTest.h
+++ b/tests/include/Parallel_AttributesTest.h
@@ -34,7 +34,9 @@ class Parallel_AttributesTest  : public CPPUNIT_NS::TestFixture
     CPPUNIT_TEST_SUITE(Parallel_AttributesTest);
 
     CPPUNIT_TEST(testDataAttributes);
+    CPPUNIT_TEST(testAttributesMeta);
     CPPUNIT_TEST(testArrayTypes);
+    CPPUNIT_TEST(testArrayAttributesMeta);
 
     CPPUNIT_TEST_SUITE_END();
 public:
@@ -43,9 +45,12 @@ public:
 private:
     void testDataAttributes();
     void testArrayTypes();
+    void testAttributesMeta();
+    void testArrayAttributesMeta();
 
     ColTypeChar ctChar;
     ColTypeInt ctInt;
+    ColTypeDouble ctDouble;
     ColTypeInt2 ctInt2;
     ColTypeInt3Array ctInt3Array;
     ColTypeDimArray ctDimArray;


### PR DESCRIPTION
- [x] Rebase on #246 
- [x] Remove deprecation suppression
- [x] Update description

This adds methods for getting the attribute meta info. Possible usage would be:

``` C++
template<typename T>
void ReadAttribute(DataCollector& dc, T& attribute){
    AttributeInfo info = dc.readAttributeInfo(42, NULL, "fooAttr");
    // Check dimensionality
    assert(info.IsScalar());

    // Assume a trait GetCollectionType that returns the collection type from a
    // given type such as int->ColTypeInt

    // Deprecated functionality for fast transition (potentially unsafe)
    assert(typeid(info.getType()) == typeid(typename GetCollectionType<T>::type));
    assert(sizeof(attribute) == info.getMemSize());
    info.read(&attribute, sizeof(attribute));

    // OR:
    // Cast data to given type. Note: This is the type of each data point. Attribute could still contain
    // an nD array of data. Each of those points may be converted and will be stored in attribute
    // so check dataspace first
    info.read(GetCollectionType<T>::type(), &attribute);
}
```

**One-Liner**:
```C++
dc.readAttributeInfo(42, NULL, "fooAttr").read(&attribute, sizeof(attribute))
```

~~Note: This might introduce unnecessary overhead. A better solution would be returning a C++ attribute class that provides basically the same interface as the AttributeInfo class but stores the HDF identifiers and loads the data on access (most data is only required once, and accessing it in HDF5 already is a copy, so one saves an additional copy) It could also provide a generic read method for getting the data.~~ (Edit: New version does that)
However HDF5 already provides a [C++ Interface](https://www.hdfgroup.org/HDF5/doc/cpplus_RM/annotated.html). Not sure if libSplash is still of use...
