### PR TITLE
Topic attributes for not existing groups

### DIFF
--- a/src/SerialDataCollector.cpp
+++ b/src/SerialDataCollector.cpp
@@ -382,6 +382,9 @@ namespace splash
         if (ndims < 1u || ndims > DSP_DIM_MAX)
             throw DCException(getExceptionString("writeAttribute", "maximum dimension `ndims` is invalid"));
 
+        /* group_path: absolute path to the last inode
+         * obj_name: last inode, can be a group or a dataset
+         */
         std::string group_path, obj_name;
         std::string dataNameInternal = "";
         if (dataName)
@@ -391,6 +394,16 @@ namespace splash
         DCGroup group;
         if (dataName)
         {
+            /* if the specified inode (obj_name) does not exist
+             * (as dataset or group), create all missing groups along group_path
+             * and even create an empty group for obj_name itself
+             *
+             * group_path + "/" + obj_name is the absolute path of dataName
+             */
+            std::string pathAndName(group_path + "/" + obj_name);
+            if(!DCGroup::exists(handles.get(id), pathAndName))
+                group.create(handles.get(id), pathAndName);
+
             // attach attribute to the dataset or group
             group.open(handles.get(0), group_path);
 

--- a/src/include/splash/DataCollector.hpp
+++ b/src/include/splash/DataCollector.hpp
@@ -366,6 +366,7 @@ namespace splash
          * @param type Type information for data.
          * @param dataName Name of the dataset in group \p id to write attribute to.
          * If dataName is NULL, the attribute is written for the iteration group.
+         * If the path dataName does not yet exist, missing groups will be created.
          * @param attrName Name of the attribute.
          * @param buf Buffer to be written as attribute.
          */

--- a/src/include/splash/core/DCGroup.hpp
+++ b/src/include/splash/core/DCGroup.hpp
@@ -59,6 +59,12 @@ namespace splash
         H5Handle openCreate(H5Handle base, std::string path) throw (DCException);
         void close() throw (DCException);
 
+        /** Check if a Group or Dataset Within a Group exist
+         *
+         * @param base open file handle
+         * @param path to either a group or data set
+         * @return true if either a dataset or a group exists at path
+         */
         static bool exists(H5Handle base, std::string path);
         static void remove(H5Handle base, std::string path) throw (DCException);
 

--- a/tests/AttributesTest.cpp
+++ b/tests/AttributesTest.cpp
@@ -78,6 +78,10 @@ void AttributesTest::testDataAttributes()
 
     dataCollector->writeAttribute(10, ctInt, NULL, "iteration", &sum2);
 
+    int groupNotExistsTestValue = 42;
+    /* check if it is possible to add an attribute to a not existing group */
+    dataCollector->writeAttribute(0, ctInt, "notExistingGroup/", "magic_number", &groupNotExistsTestValue);
+
     /* variable length string, '\0' terminated */
     const char *string_attr = {"My first c-string."};
     dataCollector->writeAttribute(10, ctString, NULL, "my_string", &string_attr);
@@ -123,6 +127,10 @@ void AttributesTest::testDataAttributes()
     attr.fileAccType = DataCollector::FAT_READ;
 
     dataCollector->open(TEST_FILE, attr);
+
+    int readGroupNotExistsTestValue = 0;
+    dataCollector->readAttribute(0, "notExistingGroup/", "magic_number", &readGroupNotExistsTestValue);
+    CPPUNIT_ASSERT(groupNotExistsTestValue == readGroupNotExistsTestValue);
 
     dataCollector->readAttribute(10, NULL, "iteration", &sum2);
 

--- a/tests/Parallel_AttributesTest.cpp
+++ b/tests/Parallel_AttributesTest.cpp
@@ -87,6 +87,10 @@ void Parallel_AttributesTest::testDataAttributes()
         dummy_data[2 * i + 1] = val_y;
     }
 
+    int groupNotExistsTestValue = 42;
+    /* check if it is possible to add an attribute to a not existing group */
+    dataCollector->writeAttribute(0, ctInt, "notExistingGroup/", "magic_number", &groupNotExistsTestValue);
+
     dataCollector->write(0, ctInt2, 1, Selection(Dimensions(BUF_SIZE, 1, 1)),
             "attr/attr2/attr3/data", dummy_data);
 
@@ -120,6 +124,10 @@ void Parallel_AttributesTest::testDataAttributes()
 
     dataCollector->open(TEST_FILE, attr);
 
+    int readGroupNotExistsTestValue = 0;
+    dataCollector->readAttribute(0, "notExistingGroup/", "magic_number", &readGroupNotExistsTestValue);
+    CPPUNIT_ASSERT(groupNotExistsTestValue == readGroupNotExistsTestValue);
+    
     sum = 0;
     neg_sum = 0;
     c = 'A';


### PR DESCRIPTION
close #231 Attribute Writing: Create Group if Missing 

extent attribute test case (paralllel/serial) 
  - write attribute to a not existing group
  - validate written attribute
extent `writeAttribute()`  (paralllel/serial) 
  - check if dataset/group exists
  - create group if not exists