### PR TITLE
Werror: On Travis Only

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,17 +20,17 @@ env:
 script:
   - cd $BUILD
 # compile libSplash and install
-  - cmake -DCMAKE_BUILD_TYPE=Debug -DTOOLS_MPI=$SPLASHMPI $SRC
+  - CXXFLAGS="-Werror" cmake -DCMAKE_BUILD_TYPE=Debug -DTOOLS_MPI=$SPLASHMPI $SRC
   - make package
   - sudo dpkg -i libsplash*.deb
   - ls -hal /usr/share/pyshared/
   - rm -rf $BUILD/*
 # compile examples/
-  - cmake -DCMAKE_BUILD_TYPE=Debug -DWITH_MPI=$SPLASHMPI $SRC/examples
+  - CXXFLAGS="-Werror" cmake -DCMAKE_BUILD_TYPE=Debug -DWITH_MPI=$SPLASHMPI $SRC/examples
   - make
   - rm -rf $BUILD/*
 # compile and run tests/
-  - cmake -DCMAKE_BUILD_TYPE=Debug -DWITH_MPI=$SPLASHMPI $SRC/tests
+  - CXXFLAGS="-Werror" cmake -DCMAKE_BUILD_TYPE=Debug -DWITH_MPI=$SPLASHMPI $SRC/tests
   - make
 # run tests
   - $SRC/tests/run_tests $BUILD

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,7 +87,7 @@ UNSET(HDF5_HAS_SHARED_POS)
 
 #-------------------------------------------------------------------------------
 
-SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Werror -Wextra -Woverloaded-virtual")
+SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Woverloaded-virtual")
 
 # options
 OPTION(DEBUG_VERBOSE "Enable verbose HDF5 debug output" OFF)


### PR DESCRIPTION
The `-Werror` flag should not be shipped to users. We will enforce it manually for travis-ci testing so the (limited) set of compilers we test stays warning-free.

Nevertheless, a (new) warning on a system or compiler we did not test is not necessarily fatal and would be a showstopper for new users.