### PR TITLE
ChangeLog for Release 1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,30 @@
 Change Log for libSplash
 ================================================================
 
+Release 1.5.0
+-------------
+**Date:** 2016-10-26
+
+Written attributes do now generate their according group path
+recursively if it does not exist and the `SerialDataCollector`
+interface for file names has been changed to be more consistent.
+
+**Interface Changes**
+
+ - `SerialDataCollector` file name interface changed #242
+ - `writeAttribute()` now creates missing groups recursively #231 #250
+
+**Bug Fixes**
+
+ - throw more exceptions on wrong usage of `ParallelDataCollector` #247
+
+**Misc**
+
+ - compiling via `-Werror` is not shipped any more #251
+ - python tools: indentiation cleanup #249
+ - `generateCollectionType` refactored, docs fixed #243 #246
+
+
 Release 1.4.0
 -------------
 **Date:** 2016-04-12

--- a/src/include/splash/version.hpp
+++ b/src/include/splash/version.hpp
@@ -25,7 +25,7 @@
 
 /** the splash version reflects the changes in API */
 #define SPLASH_VERSION_MAJOR 1
-#define SPLASH_VERSION_MINOR 4
+#define SPLASH_VERSION_MINOR 5
 #define SPLASH_VERSION_PATCH 0
 
 /** we can always handle files from the same major release


### PR DESCRIPTION
Adds the change log and bumps the version for release `1.5.0`.

This release mainly fixes non-consistent APIs to increase usebility, such as serial file naming, attribute writing and throwing on wrong usage.

The file format is unchanged.