### PR TITLE
Fix #255 DCHelper: Remove abs in size_t math

### DIFF
--- a/src/include/splash/core/DCHelper.hpp
+++ b/src/include/splash/core/DCHelper.hpp
@@ -24,8 +24,6 @@
 #define DCHELPER_H
 
 #include <map>
-#include <cmath>
-#include <cstdlib>
 #include <sstream>
 #include <iostream>
 #include <hdf5.h>
@@ -147,7 +145,7 @@ namespace splash
             while (current_chunk_size < target_chunk_size)
             {
                 // test if increasing chunk size optimizes towards target chunk size
-                size_t chunk_diff = abs(target_chunk_size - (current_chunk_size * 2));
+                size_t chunk_diff = target_chunk_size - (current_chunk_size * 2u);
                 if (chunk_diff >= last_chunk_diff)
                     break;
 


### PR DESCRIPTION
Fix #255: The `size_t` math used for optimizing the chunk-size will flip to positive values on underflow automatically, making the `abs` that causes problems on GCC 6.2 unnecessary.