### PR TITLE
Release 1.6.0: Changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,26 @@
 Change Log for libSplash
 ================================================================
 
+Release 1.6.0
+-------------
+**Date:** 2016-10-28
+
+`SerialDataCollector` file name interface change: this feature
+was accidentally not included in the `1.5.0` release.
+
+**Interface Changes**
+
+ - `SerialDataCollector` file name interface changed #242
+
+**Bug Fixes**
+
+ - compile with GCC 6.2 was broken: ambiguous `abs` #255
+
+**Misc**
+
+ - tests: remove warning on deprecated CMake usage in 3.1+ #242
+
+
 Release 1.5.0
 -------------
 **Date:** 2016-10-26

--- a/src/include/splash/version.hpp
+++ b/src/include/splash/version.hpp
@@ -25,7 +25,7 @@
 
 /** the splash version reflects the changes in API */
 #define SPLASH_VERSION_MAJOR 1
-#define SPLASH_VERSION_MINOR 5
+#define SPLASH_VERSION_MINOR 6
 #define SPLASH_VERSION_PATCH 0
 
 /** we can always handle files from the same major release


### PR DESCRIPTION
`SerialDataCollector` file name interface change #242: this feature was accidentally not included in the `1.5.0` release.

Also, [git revert](http://stackoverflow.com/questions/40285123/git-release-with-a-reverted-commit-on-master) is a tricky beast.