### PR TITLE
Keep info on H5 datatypes in collection types

### DIFF
--- a/src/include/splash/CollectionType.hpp
+++ b/src/include/splash/CollectionType.hpp
@@ -70,8 +70,12 @@ namespace splash
          */
         virtual ~CollectionType()
         {
-        };
+        }
     protected:
+        explicit CollectionType(H5DataType inType = -1): type(inType)
+        {
+        }
+
         H5DataType type;
     };
 

--- a/src/include/splash/Dimensions.hpp
+++ b/src/include/splash/Dimensions.hpp
@@ -204,6 +204,15 @@ namespace splash
         }
 
         /**
+         * Get the size in bytes of the data array.
+         * @return Size in bytes of data array.
+         */
+        inline static size_t getSize()
+        {
+            return DSP_DIM_MAX * sizeof (hsize_t);
+        }
+
+        /**
          * Get the scalar size.
          * @return Scalar number of elements spanned by all dimensions.
          */

--- a/src/include/splash/Dimensions.hpp
+++ b/src/include/splash/Dimensions.hpp
@@ -204,15 +204,6 @@ namespace splash
         }
 
         /**
-         * Get the size in bytes of the data array.
-         * @return Size in bytes of data array.
-         */
-        inline static size_t getSize()
-        {
-            return DSP_DIM_MAX * sizeof (hsize_t);
-        }
-
-        /**
          * Get the scalar size.
          * @return Scalar number of elements spanned by all dimensions.
          */

--- a/src/include/splash/basetypes/ColTypeDim.hpp
+++ b/src/include/splash/basetypes/ColTypeDim.hpp
@@ -53,7 +53,7 @@ namespace splash
 
         size_t getSize() const
         {
-            return sizeof(hsize_t) * 3;
+            return getSize_();
         }
 
         std::string toString() const
@@ -69,7 +69,7 @@ namespace splash
             {
                 if(H5Tget_nmembers(datatype_id) == 3)
                 {
-                    if(H5Tget_size(datatype_id) == getSize())
+                    if(H5Tget_size(datatype_id) == getSize_())
                     {
                         char* m0 = H5Tget_member_name(datatype_id, 0);
                         char* m1 = H5Tget_member_name(datatype_id, 1);
@@ -88,7 +88,14 @@ namespace splash
             else
                 return NULL;
         }
-    };
+    
+    private:
+        static size_t getSize_()
+        {
+            return sizeof(hsize_t) * 3;
+        }
+
+   };
 }
 
 #endif /* COLTYPEDIM_H */

--- a/src/include/splash/basetypes/ColTypeDim.hpp
+++ b/src/include/splash/basetypes/ColTypeDim.hpp
@@ -40,10 +40,10 @@ namespace splash
 
         ColTypeDim()
         {
-            this->type = H5Tcreate(H5T_COMPOUND, Dimensions::getSize());
+            this->type = H5Tcreate(H5T_COMPOUND, getSize());
             H5Tinsert(this->type, "x", 0, H5T_NATIVE_HSIZE);
-            H5Tinsert(this->type, "y", sizeof (hsize_t), H5T_NATIVE_HSIZE);
-            H5Tinsert(this->type, "z", sizeof (hsize_t) * 2, H5T_NATIVE_HSIZE);
+            H5Tinsert(this->type, "y", sizeof(hsize_t), H5T_NATIVE_HSIZE);
+            H5Tinsert(this->type, "z", sizeof(hsize_t) * 2, H5T_NATIVE_HSIZE);
         }
 
         ~ColTypeDim()
@@ -53,7 +53,7 @@ namespace splash
 
         size_t getSize() const
         {
-            return Dimensions::getSize();
+            return sizeof(hsize_t) * 3;
         }
 
         std::string toString() const
@@ -69,7 +69,7 @@ namespace splash
             {
                 if(H5Tget_nmembers(datatype_id) == 3)
                 {
-                    if(H5Tget_size(datatype_id) == Dimensions::getSize())
+                    if(H5Tget_size(datatype_id) == getSize())
                     {
                         char* m0 = H5Tget_member_name(datatype_id, 0);
                         char* m1 = H5Tget_member_name(datatype_id, 1);

--- a/src/include/splash/basetypes/ColTypeDimArray.hpp
+++ b/src/include/splash/basetypes/ColTypeDimArray.hpp
@@ -25,7 +25,7 @@
 #define COLTYPEDIMARRAY_H
 
 #include "splash/CollectionType.hpp"
-
+#include "splash/Dimensions.hpp"
 #include <string>
 
 namespace splash


### PR DESCRIPTION
Found this branch that is still not in any PR.

This keeps the actual collection type for strings and removes some entanglements of ColTypeDim with Dimensions.
The former is the most important part as it allows meaningful `isNullTerminated` and `isVariableLength` queries. Without keeping the original H5 types this would return the wrong results.