### PR TITLE
DataContainer: Fix Offset Read

### DIFF
--- a/src/include/splash/domains/DataContainer.hpp
+++ b/src/include/splash/domains/DataContainer.hpp
@@ -83,7 +83,10 @@ namespace splash
 
             for (uint32_t i = 0; i < DSP_DIM_MAX; ++i)
             {
-                offset[i] = std::min(entryOffset[i], offset[i]);
+                if (subdomains.empty())
+                    offset[i] = entryOffset[i];
+                else
+                    offset[i] = std::min(entryOffset[i], offset[i]);
                 size[i] = std::max(entryBack[i] + 1 - offset[i], size[i]);
             }
 

--- a/tests/DomainsTest.cpp
+++ b/tests/DomainsTest.cpp
@@ -222,9 +222,11 @@ void DomainsTest::subTestGridDomains(const Dimensions mpiSize,
             Dimensions subdomain_offset = subdomain->getOffset();
 
 #if defined TESTS_DEBUG
+            std::cout << "container->getSize() = " << container->getSize().toString() << std::endl;
             std::cout << "subdomain->getOffset() = " << subdomain->getOffset().toString() << std::endl;
             std::cout << "subdomain->getElements() = " << subdomain_elements.toString() << std::endl;
 #endif
+            CPPUNIT_ASSERT(container->getSize() == partition_size);
 
             int *subdomain_data = (int*) (subdomain->getData());
             CPPUNIT_ASSERT(subdomain_elements == global_grid_size - offset);


### PR DESCRIPTION
Proposed fix for #254 on which the offset >0 during reads could never be determined.

@Flamefire maybe you want to take a look? I would still like to add a test for that, but did not dig deeper.