### PR TITLE
Changelog & Version Bump: 1.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,35 @@
 Change Log for libSplash
 ================================================================
 
+Release 1.7.0
+-------------
+**Date:** 2018-01-22
+
+This release adds modernized CMake scripts including CMake config
+packages on install with targets. A new `readAttributeInfo` method
+was added to the `DataCollector` for save reading of types and
+extends of attributes. On reads, the `offset` in `DataContainer` for
+non-zero offsets in domains was fixed. Due to a bug in upsteam CMake,
+at least version 3.10.0 of CMake is required now.
+
+**Interface Changes**
+
+ - new read method: attribute meta info #248 #268
+ - keep info on H5 datatypes in collection types #259
+
+**Bug Fixes**
+
+ - `DataContainer`: fix offset read #263
+ - `FindHDF5.cmake`: use upstream CMake version #267
+
+**Misc**
+
+ - modern CMake3 scripts #269
+ - fix GitHub badges #254 #264
+ 
+Thanks to Axel Huebl and Alexander Grund for contributions to this release!
+
+
 Release 1.6.0
 -------------
 **Date:** 2016-10-28

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Release 1.7.0
 This release adds modernized CMake scripts including CMake config
 packages on install with targets. A new `readAttributeInfo` method
 was added to the `DataCollector` for save reading of types and
-extends of attributes. On reads, the `offset` in `DataContainer` for
+extents of attributes. On reads, the `offset` in `DataContainer` for
 non-zero offsets in domains was fixed. Due to a bug in upsteam CMake,
 at least version 3.10.0 of CMake is required now.
 

--- a/README.md
+++ b/README.md
@@ -27,10 +27,10 @@ libSplash is developed and maintained by the
 ([ZIH](http://tu-dresden.de/die_tu_dresden/zentrale_einrichtungen/zih)) of the
 Technical University Dresden ([TUD](http://www.tu-dresden.de))
 in close collaboration with the
-**[Junior Group Computational Radiation Physics](http://www.hzdr.de/db/Cms?pNid=132&pOid=30354)**
+**[Group Computational Radiation Physics](http://www.hzdr.de/db/Cms?pNid=132&pOid=30354)**
 at the [Institute for Radiation Physics](http://www.hzdr.de/db/Cms?pNid=132)
 at [HZDR](http://www.hzdr.de/)
-We are a member of the [Dresden CUDA Center of Excellence](http://ccoe-dresden.de/) that
+We are a member of the [Dresden GPU Center of Excellence](http://gcoe-dresden.de/) that
 cooperates on a broad range of scientific CUDA applications, workshops and
 teaching efforts.
 libSplash is actively used in the **PIConGPU** project for large-scale GPU-based particle-in-cell
@@ -66,7 +66,7 @@ Active Team
 
 ### Maintainers* and developers
 
-- Axel Huebl
+- Axel Huebl*
 - Felix Schmitt*
 - Rene Widera
 - Alexander Grund

--- a/src/include/splash/version.hpp
+++ b/src/include/splash/version.hpp
@@ -25,7 +25,7 @@
 
 /** the splash version reflects the changes in API */
 #define SPLASH_VERSION_MAJOR 1
-#define SPLASH_VERSION_MINOR 6
+#define SPLASH_VERSION_MINOR 7
 #define SPLASH_VERSION_PATCH 0
 
 /** we can always handle files from the same major release


### PR DESCRIPTION
Release 1.7.0
-------------
**Date:** 2018-01-22

This release adds modernized CMake scripts including CMake config packages on install with targets. A new `readAttributeInfo` method was added to the `DataCollector` for save reading of types and extents of attributes. On reads, the `offset` in `DataContainer` for non-zero offsets in domains was fixed. Due to a bug in upsteam CMake, at least version 3.10.0 of CMake is required now.

**Interface Changes**

 - new read method: attribute meta info #248 #268
 - keep info on H5 datatypes in collection types #259

**Bug Fixes**

 - `DataContainer`: fix offset read #263
 - `FindHDF5.cmake`: use upstream CMake version #267

**Misc**

 - modern CMake3 scripts #269
 - fix GitHub badges #254 #264
 
Thanks to @ax3l and @Flamefire for contributions to this release!