### PR TITLE
H5DWrite: Print Error Stack

### DIFF
--- a/src/DCDataSet.cpp
+++ b/src/DCDataSet.cpp
@@ -583,7 +583,10 @@ namespace splash
             // write data to the dataset
 
             if (H5Dwrite(dataset, this->datatype, dsp_src, dataspace, dsetWriteProperties, data) < 0)
+            {
+                H5Eprint(H5E_DEFAULT, stderr);
                 throw DCException(getExceptionString("write: Failed to write dataset"));
+            }
 
             H5Sclose(dsp_src);
         }


### PR DESCRIPTION
Print HDF5 error stack before throwing in writes.

Try to get more verbose output for @berceanu in https://github.com/ComputationalRadiationPhysics/picongpu/issues/2777

Related to #161 

- [x] let's see if this adds more info first