### PR TITLE
ColTypeDim et al.: Fix Potential Segfault

### DIFF
--- a/src/include/splash/basetypes/ColTypeBool.hpp
+++ b/src/include/splash/basetypes/ColTypeBool.hpp
@@ -71,8 +71,8 @@ public:
                 char* m1 = H5Tget_member_name(datatype_id,1);
                 if(strcmp("TRUE" , m0) == 0 && strcmp("FALSE", m1) == 0)
                     found = true;
-                free(m1);
-                free(m0);
+                H5free_memory(m1);
+                H5free_memory(m0);
             }
         }
 

--- a/src/include/splash/basetypes/ColTypeBool.hpp
+++ b/src/include/splash/basetypes/ColTypeBool.hpp
@@ -69,8 +69,9 @@ public:
             {
                 char* m0 = H5Tget_member_name(datatype_id,0);
                 char* m1 = H5Tget_member_name(datatype_id,1);
-                if(strcmp("TRUE" , m0) == 0 && strcmp("FALSE", m1) == 0)
-                    found = true;
+                if(m0 != NULL && m1 != NULL)
+                    if(strcmp("TRUE" , m0) == 0 && strcmp("FALSE", m1) == 0)
+                        found = true;
                 H5free_memory(m1);
                 H5free_memory(m0);
             }

--- a/src/include/splash/basetypes/ColTypeDim.hpp
+++ b/src/include/splash/basetypes/ColTypeDim.hpp
@@ -74,8 +74,9 @@ namespace splash
                         char* m0 = H5Tget_member_name(datatype_id, 0);
                         char* m1 = H5Tget_member_name(datatype_id, 1);
                         char* m2 = H5Tget_member_name(datatype_id, 2);
-                        if(strcmp("x", m0) == 0 && strcmp("y", m1) == 0 && strcmp("z", m2) == 0)
-                            found = true;
+                        if(m0 != NULL && m1 != NULL && m2 != NULL)
+                            if(strcmp("x", m0) == 0 && strcmp("y", m1) == 0 && strcmp("z", m2) == 0)
+                                found = true;
 
                         H5free_memory(m2);
                         H5free_memory(m1);

--- a/src/include/splash/basetypes/ColTypeDim.hpp
+++ b/src/include/splash/basetypes/ColTypeDim.hpp
@@ -77,9 +77,9 @@ namespace splash
                         if(strcmp("x", m0) == 0 && strcmp("y", m1) == 0 && strcmp("z", m2) == 0)
                             found = true;
 
-                        free(m2);
-                        free(m1);
-                        free(m0);
+                        H5free_memory(m2);
+                        H5free_memory(m1);
+                        H5free_memory(m0);
                     }
                 }
             }

--- a/src/include/splash/basetypes/basetypes_compound.hpp
+++ b/src/include/splash/basetypes/basetypes_compound.hpp
@@ -69,10 +69,13 @@ namespace splash
                     {                                                          \
                         hid_t mtype = H5Tget_member_type(datatype_id, i);      \
                         char* mname = H5Tget_member_name(datatype_id, i);      \
-                        if(H5Tequal(mtype, _h5_type) == 1 &&                   \
-                           strcmp(COMPOUND_ELEMENTS[i], mname) == 0)           \
+                        if(mname != NULL)                                      \
                         {                                                      \
-                            found = true;                                      \
+                            if(H5Tequal(mtype, _h5_type) == 1 &&               \
+                               strcmp(COMPOUND_ELEMENTS[i], mname) == 0)       \
+                            {                                                  \
+                               found = true;                                   \
+                            }                                                  \
                         }                                                      \
                         H5free_memory(mname);                                  \
                         H5Tclose(mtype);                                       \

--- a/src/include/splash/basetypes/basetypes_compound.hpp
+++ b/src/include/splash/basetypes/basetypes_compound.hpp
@@ -74,7 +74,7 @@ namespace splash
                         {                                                      \
                             found = true;                                      \
                         }                                                      \
-                        free(mname);                                           \
+                        H5free_memory(mname);                                  \
                         H5Tclose(mtype);                                       \
                     }                                                          \
                 }                                                              \


### PR DESCRIPTION
From the docs:
```
Name: H5Tget_member_name
  ...
  The HDF5 Library allocates a buffer to receive the name of the
  field. The caller must subsequently free the buffer with
  H5free_memory.
```

Also: passing `NULL` to `str(n)cmp` is undefined behavior.

Refs.:
- https://support.hdfgroup.org/HDF5/doc/RM/RM_H5T.html#Datatype-GetMemberName
- https://support.hdfgroup.org/HDF5/doc/RM/RM_H5.html#Library-FreeMemory
- 2da14a60f2244881829d95987ac6f90cfd34a33b
- https://github.com/openPMD/openPMD-api/pull/962